### PR TITLE
Added Path based config

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/file/CommentedFileConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/CommentedFileConfig.java
@@ -2,6 +2,7 @@ package com.electronwill.nightconfig.core.file;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 
 import java.io.File;
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/FileConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/FileConfig.java
@@ -2,6 +2,7 @@ package com.electronwill.nightconfig.core.file;
 
 import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 
 import java.io.File;
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/ConfigWriter.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/ConfigWriter.java
@@ -7,6 +7,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Interface for writing configurations.
@@ -69,6 +72,23 @@ public interface ConfigWriter {
 		boolean append = (writingMode == WritingMode.APPEND);
 		try (Writer writer = new BufferedWriter(
 				new OutputStreamWriter(new FileOutputStream(file, append), charset))) {
+			write(config, writer);
+		} catch (IOException e) {
+			throw new WritingException("An I/O error occured", e);
+		}
+	}
+
+	/**
+	 * Writes a configuration.
+	 *
+	 * @param config the config to write
+	 * @param path   the path to write it to
+	 * @throws WritingException if an error occurs
+	 */
+	default void write(UnmodifiableConfig config, Path path, WritingMode writingMode, Charset charset) {
+		boolean append = (writingMode == WritingMode.APPEND);
+		try (Writer writer = new BufferedWriter(
+			new OutputStreamWriter(Files.newOutputStream(path, append? StandardOpenOption.APPEND: StandardOpenOption.TRUNCATE_EXISTING), charset))) {
 			write(config, writer);
 		} catch (IOException e) {
 			throw new WritingException("An I/O error occured", e);

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/FormatDetector.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/FormatDetector.java
@@ -1,9 +1,10 @@
-package com.electronwill.nightconfig.core.file;
+package com.electronwill.nightconfig.core.io;
 
 import com.electronwill.nightconfig.core.ConfigFormat;
 import com.electronwill.nightconfig.core.utils.StringUtils;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +49,9 @@ public final class FormatDetector {
 		return detectByName(file.getName());
 	}
 
+	public static ConfigFormat<?> detect(Path path) {
+		return detectByName(path.getFileName().toString());
+	}
 	/**
 	 * Detects the ConfigFormat of a filename.
 	 *

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/AutoreloadPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/AutoreloadPathConfig.java
@@ -1,0 +1,43 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.utils.ConfigWrapper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * @author TheElectronWill
+ */
+final class AutoreloadPathConfig<C extends PathConfig> extends ConfigWrapper<C> implements PathConfig {
+	private final PathWatcher watcher = PathWatcher.defaultInstance();
+
+	AutoreloadPathConfig(C config) {
+		super(config);
+		try {
+			watcher.addWatch(config.getPath(), config::load);
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to create the autoreloaded config", e);
+		}
+	}
+
+	@Override
+	public Path getPath() {
+		return config.getPath();
+	}
+
+	@Override
+	public void save() {
+		config.save();
+	}
+
+	@Override
+	public void load() {
+		config.load();
+	}
+
+	@Override
+	public void close() {
+		watcher.removeWatch(config.getPath());
+		config.close();
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/AutosavePathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/AutosavePathConfig.java
@@ -1,0 +1,63 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.utils.ConfigWrapper;
+import com.electronwill.nightconfig.core.utils.ObservedMap;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author TheElectronWill
+ */
+final class AutosavePathConfig<C extends PathConfig> extends ConfigWrapper<C> implements PathConfig {
+	AutosavePathConfig(C config) {
+		super(config);
+	}
+
+	@Override
+	public <T> T set(List<String> path, Object value) {
+		T result = super.set(path, value);
+		save();
+		return result;
+	}
+
+	@Override
+	public boolean add(List<String> path, Object value) {
+		boolean result = super.add(path, value);
+		save();
+		return result;
+	}
+
+	@Override
+	public <T> T remove(List<String> path) {
+		T result = super.remove(path);
+		save();
+		return result;
+	}
+
+	@Override
+	public Map<String, Object> valueMap() {
+		return new ObservedMap<>(super.valueMap(), this::save);
+	}
+
+	@Override
+	public Path getPath() {
+		return config.getPath();
+	}
+
+	@Override
+	public void save() {
+		config.save();
+	}
+
+	@Override
+	public void load() {
+		config.load();
+	}
+
+	@Override
+	public void close() {
+		config.close();
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/CheckedCommentedPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/CheckedCommentedPathConfig.java
@@ -1,0 +1,107 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.utils.CommentedConfigWrapper;
+import com.electronwill.nightconfig.core.utils.TransformingMap;
+import com.electronwill.nightconfig.core.utils.TransformingSet;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author TheElectronWill
+ */
+class CheckedCommentedPathConfig extends CommentedConfigWrapper<CommentedPathConfig>
+		implements CommentedPathConfig {
+	/**
+	 * Creates a new CheckedConfig around a commented configuration.
+	 * <p>
+	 * The values that are in the config when this method is called are also checked.
+	 *
+	 * @param config the configuration to wrap
+	 */
+	CheckedCommentedPathConfig(CommentedPathConfig config) {
+		super(config);
+	}
+
+	@Override
+	public Path getPath() {
+		return config.getPath();
+	}
+
+	@Override
+	public void save() {
+		config.save();
+	}
+
+	@Override
+	public void load() {
+		config.load();
+	}
+
+	@Override
+	public void close() {
+		config.close();
+	}
+
+	@Override
+	public CommentedPathConfig checked() {
+		return this;
+	}
+
+	@Override
+	public <T> T set(List<String> path, Object value) {
+		return super.set(path, checkedValue(value));
+	}
+
+	@Override
+	public boolean add(List<String> path, Object value) {
+		return super.add(path, checkedValue(value));
+	}
+
+	@Override
+	public Map<String, Object> valueMap() {
+		return new TransformingMap<>(super.valueMap(), v -> v, this::checkedValue, o -> o);
+	}
+
+	@Override
+	public Set<? extends CommentedConfig.Entry> entrySet() {
+		return new TransformingSet<>((Set<CommentedConfig.Entry>)super.entrySet(), v -> v, this::checkedValue, o -> o);
+	}
+
+	@Override
+	public String toString() {
+		return "checked of " + config;
+	}
+
+	/**
+	 * Checks that a value is supported by the config. Throws an unchecked exception if the value
+	 * isn't supported.
+	 */
+	private void checkValue(Object value) {
+		ConfigFormat<?> format = configFormat();
+		if (value != null && !format.supportsType(value.getClass())) {
+			throw new IllegalArgumentException(
+					"Unsupported value type: " + value.getClass().getTypeName());
+		} else if (value == null && !format.supportsType(null)) {
+			throw new IllegalArgumentException(
+					"Null values aren't supported by this configuration.");
+		}
+		if (value instanceof Config) {
+			((Config)value).valueMap().forEach((k, v) -> checkValue(v));
+		}
+	}
+
+	/**
+	 * Checks that a value is supported by the config, and returns it if it's supported. Throws an
+	 * unchecked exception if the value isn't supported.
+	 */
+	private <T> T checkedValue(T value) {
+		checkValue(value);
+		return value;
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/CheckedPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/CheckedPathConfig.java
@@ -1,0 +1,105 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.utils.ConfigWrapper;
+import com.electronwill.nightconfig.core.utils.TransformingMap;
+import com.electronwill.nightconfig.core.utils.TransformingSet;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author TheElectronWill
+ */
+class CheckedPathConfig extends ConfigWrapper<PathConfig> implements PathConfig {
+	/**
+	 * Creates a new CheckedConfig around a given configuration.
+	 * <p>
+	 * The values that are in the config when this method is called are also checked.
+	 *
+	 * @param config the configuration to wrap
+	 */
+	CheckedPathConfig(PathConfig config) {
+		super(config);
+	}
+
+	@Override
+	public Path getPath() {
+		return config.getPath();
+	}
+
+	@Override
+	public void save() {
+		config.save();
+	}
+
+	@Override
+	public void load() {
+		config.load();
+	}
+
+	@Override
+	public void close() {
+		config.close();
+	}
+
+	@Override
+	public PathConfig checked() {
+		return this;
+	}
+
+	@Override
+	public <T> T set(List<String> path, Object value) {
+		return super.set(path, checkedValue(value));
+	}
+
+	@Override
+	public boolean add(List<String> path, Object value) {
+		return super.add(path, checkedValue(value));
+	}
+
+	@Override
+	public Map<String, Object> valueMap() {
+		return new TransformingMap<>(super.valueMap(), v -> v, this::checkedValue, o -> o);
+	}
+
+	@Override
+	public Set<? extends Config.Entry> entrySet() {
+		return new TransformingSet<>((Set<Config.Entry>)super.entrySet(), v -> v, this::checkedValue, o -> o);
+	}
+
+	@Override
+	public String toString() {
+		return "checked of " + config;
+	}
+
+	/**
+	 * Checks that a value is supported by the config. Throws an unchecked exception if the value
+	 * isn't supported.
+	 */
+	private void checkValue(Object value) {
+		ConfigFormat<?> format = configFormat();
+		if (value != null && !format.supportsType(value.getClass())) {
+			throw new IllegalArgumentException(
+					"Unsupported value type: " + value.getClass().getTypeName());
+		} else if (value == null && !format.supportsType(null)) {
+			throw new IllegalArgumentException(
+					"Null values aren't supported by this configuration.");
+		}
+		if (value instanceof Config) {
+			((Config)value).valueMap().forEach((k, v) -> checkValue(v));
+		}
+	}
+
+	/**
+	 * Checks that a value is supported by the config, and returns it if it's supported. Throws an
+	 * unchecked exception if the value isn't supported.
+	 */
+	private <T> T checkedValue(T value) {
+		checkValue(value);
+		return value;
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/CommentedPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/CommentedPathConfig.java
@@ -1,0 +1,174 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.FormatDetector;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author TheElectronWill
+ */
+public interface CommentedPathConfig extends CommentedConfig, PathConfig {
+	@Override
+	default CommentedPathConfig checked() {
+		return new CheckedCommentedPathConfig(this);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified path and format.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new PathConfig associated to the specified path
+	 */
+	static CommentedPathConfig of(Path path, ConfigFormat<? extends CommentedConfig> format) {
+		return builder(path, format).build();
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified path and format. The format is detected
+	 * automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new PathConfig associated to the specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfig of(Path path) {
+		ConfigFormat format = FormatDetector.detect(path);
+		if (format == null || !format.supportsComments()) {
+			throw new NoFormatFoundException("No suitable format for " + path.getFileName());
+		}
+		return of(path, format);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified file and format.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new PathConfig associated to the specified file
+	 */
+	static CommentedPathConfig of(String filePath, ConfigFormat<? extends CommentedConfig> format) {
+		return of(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified file and format. The format is detected
+	 * automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new PathConfig associated to the specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfig of(String filePath) {
+		return of(Paths.get(filePath));
+	}
+
+	/**
+	 * Creates a new trhead-safe CommentedPathConfig based on the specified path and format.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new thread-safe CommentedPathConfig associated to the specified path
+	 */
+	static CommentedPathConfig ofConcurrent(Path path, ConfigFormat<? extends CommentedConfig> format) {
+		return builder(path, format).concurrent().build();
+	}
+
+	/**
+	 * Creates a new thread-safe CommentedPathConfig based on the specified path and format. The
+	 * format is detected automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new thread-safe CommentedPathConfig associated to the specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfig ofConcurrent(Path path) {
+		return builder(path).concurrent().build();
+	}
+
+	/**
+	 * Creates a new trhead-safe CommentedPathConfig based on the specified file and format.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new thread-safe CommentedPathConfig associated to the specified file
+	 */
+	static CommentedPathConfig ofConcurrent(String filePath, ConfigFormat<? extends CommentedConfig> format) {
+		return ofConcurrent(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Creates a new trhead-safe CommentedPathConfig based on the specified file and format. The
+	 * format is detected automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new thread-safe CommentedPathConfig associated to the specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfig ofConcurrent(String filePath) {
+		return ofConcurrent(Paths.get(filePath));
+	}
+
+	/**
+	 * Returns a CommentedPathConfigBuilder to create a CommentedPathConfig with many options.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new PathConfigBuilder that will build a CommentedPathConfig associated to the
+	 * specified path
+	 */
+	static CommentedPathConfigBuilder builder(Path path, ConfigFormat<? extends CommentedConfig> format) {
+		return new CommentedPathConfigBuilder(path, format);
+	}
+
+	/**
+	 * Returns a CommentedPathConfigBuilder to create a CommentedPathConfig with many options. The
+	 * format is detected automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new PathConfigBuilder that will build a CommentedPathConfig associated to the
+	 * specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfigBuilder builder(Path path) {
+		ConfigFormat format = FormatDetector.detect(path);
+		if (format == null || !format.supportsComments()) {
+			throw new NoFormatFoundException("No suitable format for " + path.getFileName());
+		}
+		return builder(path, format);
+	}
+
+	/**
+	 * Returns a CommentedPathConfigBuilder to create a CommentedPathConfig with many options.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new PathConfigBuilder that will build a CommentedPathConfig associated to the
+	 * specified file
+	 */
+	static CommentedPathConfigBuilder builder(String filePath, ConfigFormat<? extends CommentedConfig> format) {
+		return builder(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Returns a CommentedPathConfigBuilder to create a CommentedPathConfig with many options. The
+	 * format is detected automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new PathConfigBuilder that will build a CommentedPathConfig associated to the
+	 * specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static CommentedPathConfigBuilder builder(String filePath) {
+		return builder(Paths.get(filePath));
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/CommentedPathConfigBuilder.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/CommentedPathConfigBuilder.java
@@ -1,0 +1,102 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.ParsingMode;
+import com.electronwill.nightconfig.core.io.WritingMode;
+
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+/**
+ * Builder for CommentedPathConfig. The default settings are:
+ * <ul>
+ * <li>Charset: UTF-8 - change it with {@link #charset(Charset)}</li>
+ * <li>WritingMode: REPLACE - change it with {@link #writingMode(WritingMode)}</li>
+ * <li>ParsingMode: REPLACE - change it with {@link #parsingMode(ParsingMode)}</li>
+ * <li>PathNotFoundAction: CREATE_EMPTY - change it with {@link #onFileNotFound(PathNotFoundAction)}</li>
+ * <li>Asynchronous writing, ie config.save() returns quickly and operates in the background -
+ * change it with {@link #sync()}</li>
+ * <li>Not autosaved - change it with {@link #autosave()}</li>
+ * <li>Not autoreloaded - change it with {@link #autoreload()}</li>
+ * <li>Not thread-safe - change it with {@link #concurrent()}</li>
+ * </ul>
+ *
+ * @author TheElectronWill
+ */
+public final class CommentedPathConfigBuilder extends PathConfigBuilder<CommentedConfig> {
+	CommentedPathConfigBuilder(Path path, ConfigFormat<? extends CommentedConfig> format) {
+		super(path, format);
+	}
+
+	@Override
+	public CommentedPathConfigBuilder charset(Charset charset) {
+		super.charset(charset);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder writingMode(WritingMode writingMode) {
+		super.writingMode(writingMode);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder parsingMode(ParsingMode parsingMode) {
+		super.parsingMode(parsingMode);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder onFileNotFound(PathNotFoundAction nefAction) {
+		super.onFileNotFound(nefAction);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder defaultResource(String resourcePath) {
+		super.defaultResource(resourcePath);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder defaultData(Path path) {
+		super.defaultData(path);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder defaultData(URL url) {
+		super.defaultData(url);
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder sync() {
+		super.sync();
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder autosave() {
+		super.autosave();
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder autoreload() {
+		super.autoreload();
+		return this;
+	}
+
+	@Override
+	public CommentedPathConfigBuilder concurrent() {
+		super.concurrent();
+		return this;
+	}
+
+	public CommentedPathConfig build() {
+		return new SimpleCommentedPathConfig(getConfig(), super.build());
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/NoFormatFoundException.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/NoFormatFoundException.java
@@ -1,0 +1,14 @@
+package com.electronwill.nightconfig.core.path;
+
+/**
+ * @author TheElectronWill
+ */
+public class NoFormatFoundException extends RuntimeException {
+	public NoFormatFoundException(String message) {
+		super(message);
+	}
+
+	public NoFormatFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/PathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/PathConfig.java
@@ -1,0 +1,195 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.FormatDetector;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * @author TheElectronWill
+ */
+public interface PathConfig extends Config, AutoCloseable {
+	/**
+	 * @return the config's file
+	 */
+	Path getPath();
+
+	/**
+	 * Saves this config as soon as possible. This method may return quickly and perform the IO
+	 * operations in background, or it may block until the operations are done.
+	 */
+	void save();
+
+	/**
+	 * (Re)loads this config from the file. This method blocks until the read operation completes.
+	 */
+	void load();
+
+	/**
+	 * Closes this PathConfig, releases its associated resources (if any), and ensure that the
+	 * ongoing saving operations complete.
+	 * <p>
+	 * A closed PathConfig can still be used via the Config's methods, but {@link #save()} and
+	 * {@link #load()} will throw an IllegalStateException. Closing an aleady closed PathConfig has
+	 * no effect.
+	 */
+	@Override
+	void close();
+
+	@Override
+	default PathConfig checked() {
+		return new CheckedPathConfig(this);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified path and format.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new PathConfig associated to the specified path
+	 */
+	static PathConfig of(Path path, ConfigFormat<? extends Config> format) {
+		return builder(path, format).build();
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified path. The format is detected automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new PathConfig associated to the specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfig of(Path path) {
+		ConfigFormat format = FormatDetector.detect(path);
+		if (format == null) {
+			throw new NoFormatFoundException("No suitable format for " + path.getFileName());
+		}
+		return of(path, format);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified file and format.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new PathConfig associated to the specified file
+	 */
+	static PathConfig of(String filePath, ConfigFormat<?> format) {
+		return of(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Creates a new PathConfig based on the specified file. The format is detected automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new PathConfig associated to the specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfig of(String filePath) {
+		return of(Paths.get(filePath));
+	}
+
+	/**
+	 * Creates a new thread-safe PathConfig based on the specified path and format.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new thread-safe PathConfig associated to the specified path
+	 */
+	static PathConfig ofConcurrent(Path path, ConfigFormat<?> format) {
+		return builder(path, format).concurrent().build();
+	}
+
+	/**
+	 * Creates a new thread-safe PathConfig based on the specified path. The format is detected
+	 * automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new thread-safe PathConfig associated to the specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfig ofConcurrent(Path path) {
+		return builder(path).concurrent().build();
+	}
+
+	/**
+	 * Creates a new thread-safe PathConfig based on the specified file and format.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new thread-safe PathConfig associated to the specified file
+	 */
+	static PathConfig ofConcurrent(String filePath, ConfigFormat<?> format) {
+		return ofConcurrent(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Creates a new thread-safe PathConfig based on the specified file. The format is detected
+	 * automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new thread-safe PathConfig associated to the specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfig ofConcurrent(String filePath) {
+		return ofConcurrent(Paths.get(filePath));
+	}
+
+	/**
+	 * Returns a PathConfigBuilder to create a PathConfig with many options.
+	 *
+	 * @param path   the path to use to save and load the config
+	 * @param format the config's format
+	 * @return a new PathConfigBuilder that will build a PathConfig associated to the specified path
+	 */
+	static PathConfigBuilder<Config> builder(Path path, ConfigFormat<?> format) {
+		return new PathConfigBuilder<>(path, format);
+	}
+
+	/**
+	 * Returns a PathConfigBuilder to create a PathConfig with many options. The format is detected
+	 * automatically.
+	 *
+	 * @param path the path to use to save and load the config
+	 * @return a new PathConfigBuilder that will build a PathConfig associated to the specified path
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfigBuilder<Config> builder(Path path) {
+		ConfigFormat format = FormatDetector.detect(path);
+		if (format == null) {
+			throw new NoFormatFoundException("No suitable format for " + path.getFileName());
+		}
+		return builder(path, format);
+	}
+
+	/**
+	 * Returns a PathConfigBuilder to create a PathConfig with many options.
+	 *
+	 * @param filePath the file's path
+	 * @param format   the config's format
+	 * @return a new PathConfigBuilder that will build a PathConfig associated to the specified file
+	 */
+	static PathConfigBuilder<Config> builder(String filePath, ConfigFormat<?> format) {
+		return builder(Paths.get(filePath), format);
+	}
+
+	/**
+	 * Returns a PathConfigBuilder to create a PathConfig with many options. The format is detected
+	 * automatically.
+	 *
+	 * @param filePath the file's path
+	 * @return a new PathConfigBuilder that will build a PathConfig associated to the specified file
+	 *
+	 * @throws NoFormatFoundException if the format detection fails
+	 */
+	static PathConfigBuilder<Config> builder(String filePath) {
+		return builder(Paths.get(filePath));
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/PathConfigBuilder.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/PathConfigBuilder.java
@@ -1,0 +1,208 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.io.*;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Builder for PathConfig. The default settings are:
+ * <ul>
+ * <li>Charset: UTF-8 - change it with {@link #charset(Charset)}</li>
+ * <li>WritingMode: REPLACE - change it with {@link #writingMode(WritingMode)}</li>
+ * <li>ParsingMode: REPLACE - change it with {@link #parsingMode(ParsingMode)}</li>
+ * <li>PathNotFoundAction: CREATE_EMPTY - change it with {@link #onFileNotFound(PathNotFoundAction)}</li>
+ * <li>Asynchronous writing, ie config.save() returns quickly and operates in the background -
+ * change it with {@link #sync()}</li>
+ * <li>Not autosaved - change it with {@link #autosave()}</li>
+ * <li>Not autoreloaded - change it with {@link #autoreload()}</li>
+ * <li>Not thread-safe - change it with {@link #concurrent()}</li>
+ * </ul>
+ *
+ * @author TheElectronWill
+ */
+public class PathConfigBuilder<C extends Config> {
+	protected final Path path;
+	private C config;
+	protected final ConfigFormat<?> format;
+	protected final ConfigWriter writer;
+	protected final ConfigParser<?> parser;
+	protected Charset charset = StandardCharsets.UTF_8;
+	protected WritingMode writingMode = WritingMode.REPLACE;
+	protected ParsingMode parsingMode = ParsingMode.REPLACE;
+	protected PathNotFoundAction nefAction = PathNotFoundAction.CREATE_EMPTY;
+	protected boolean sync = false, autosave = false, autoreload = false;
+
+	PathConfigBuilder(Path path, ConfigFormat<? extends C> format) {
+		this.path = path;
+		this.format = format;
+		this.writer = format.createWriter();
+		this.parser = format.createParser();
+	}
+
+	/**
+	 * Sets the charset used for {@link PathConfig#save()} and {@link PathConfig#load()}.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> charset(Charset charset) {
+		this.charset = charset;
+		return this;
+	}
+
+	/**
+	 * Sets the WritingMode used for {@link PathConfig#save()}
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> writingMode(WritingMode writingMode) {
+		this.writingMode = writingMode;
+		return this;
+	}
+
+	/**
+	 * Sets the ParsingMode used for {@link PathConfig#load()}
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> parsingMode(ParsingMode parsingMode) {
+		this.parsingMode = parsingMode;
+		return this;
+	}
+
+	/**
+	 * Sets the action to execute when the config's file is not found.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> onFileNotFound(PathNotFoundAction nefAction) {
+		this.nefAction = nefAction;
+		return this;
+	}
+
+	/**
+	 * Sets the resource (in the jar) to copy when the config's file is not found. This is a
+	 * shortcut for {@code onFileNotFound(PathNotFoundAction.copyResource(resourcePath))}
+	 *
+	 * @param resourcePath the resource's path
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> defaultResource(String resourcePath) {
+		return onFileNotFound(PathNotFoundAction.copyResource(resourcePath));
+	}
+
+	/**
+	 * Sets the path to copy when the config's path is not found. This is a shortcut for {@code
+	 * onFileNotFound(PathNotFoundAction.copyData(path))}
+	 *
+	 * @param path the data path
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> defaultData(Path path) {
+		return onFileNotFound(PathNotFoundAction.copyData(path));
+	}
+
+	/**
+	 * Sets the URL of the data to copy when the config's file is not found. This is a shortcut for
+	 * {@code onFileNotFound(PathNotFoundAction.copyData(url))}
+	 *
+	 * @param url the data url
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> defaultData(URL url) {
+		return onFileNotFound(PathNotFoundAction.copyData(url));
+	}
+
+	/**
+	 * Makes the configuration "write-synchronized", that is, its {@link PathConfig#save()}
+	 * method blocks until the write operation completes.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> sync() {
+		sync = true;
+		return this;
+	}
+
+	/**
+	 * Makes the configuration "autosaved", that is, its {@link PathConfig#save()} method is
+	 * automatically called when it is modified.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> autosave() {
+		autosave = true;
+		return this;
+	}
+
+	/**
+	 * Makes the configuration "autoreloaded", that is, its {@link PathConfig#load()} method is
+	 * automatically called when the file is modified.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> autoreload() {
+		autoreload = true;
+		return this;
+	}
+
+	/**
+	 * Makes the configuration concurrent, that is, thread-safe.
+	 *
+	 * @return this builder
+	 */
+	public PathConfigBuilder<C> concurrent() {
+		config = (C)format.createConcurrentConfig();
+		return this;
+	}
+
+	/**
+	 * Creates a new PathConfig with the chosen settings.
+	 *
+	 * @return the config
+	 */
+	public PathConfig build() {
+		PathConfig pathConfig;
+		if (sync) {
+			pathConfig = new WriteSyncPathConfig<>(getConfig(), path, charset, writer, writingMode,
+												   parser, parsingMode, nefAction);
+		} else {
+			if (autoreload) {
+				concurrent();
+				// Autoreloading is done from a background thread, therefore we need thread-safety
+				// This isn't needed with WriteSyncPathConfig because it synchronizes loads and writes.
+			}
+			pathConfig = new WriteAsyncPathConfig<>(getConfig(), path, charset, writer, writingMode,
+													parser, parsingMode, nefAction);
+		}
+		if (autoreload) {
+			if (!Files.exists(path)) {
+				try {
+					nefAction.run(path);
+				} catch (IOException e) {
+					throw new WritingException("An exception occured while executing the "
+											   + "PathNotFoundAction for file "
+											   + path, e);
+				}
+			}
+			pathConfig = new AutoreloadPathConfig<>(pathConfig);
+		}
+		if (autosave) {
+			pathConfig = new AutosavePathConfig<>(pathConfig);
+		}
+		return pathConfig;
+	}
+
+	protected final C getConfig() {
+		if (config == null) {// concurrent() has not been called
+			config = (C)format.createConfig();
+		}
+		return config;
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/PathNotFoundAction.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/PathNotFoundAction.java
@@ -1,0 +1,90 @@
+package com.electronwill.nightconfig.core.path;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+/**
+ * Defines the action to perform when the file is not found.
+ *
+ * @author TheElectronWill
+ */
+@FunctionalInterface
+public interface PathNotFoundAction {
+	/**
+	 * Performs the action.
+	 *
+	 * @return {@code true} to parse the path, {@code false} to stop after the action's execution
+	 * (thus making the config empty)
+	 *
+	 * @throws IOException if an IO error occurs
+	 */
+	boolean run(Path path) throws IOException;
+
+	// --- Static members ---
+
+	PathNotFoundAction CREATE_EMPTY = path -> {
+		Files.createFile(path);
+		return false;
+	};
+	PathNotFoundAction READ_NOTHING = f -> false;
+	PathNotFoundAction THROW_ERROR = f -> {
+		throw new NoSuchFileException(f.toString());
+	};
+
+	/**
+	 * Action: copies the data at the given url.
+	 *
+	 * @param url the data url
+	 * @return a PathNotFoundAction that copies the url's data if the file is not found
+	 */
+	static PathNotFoundAction copyData(URL url) {
+		return f -> {
+			Files.copy(url.openStream(), f);
+			return true;
+		};
+	}
+
+	/**
+	 * Action: copies the specified file.
+	 *
+	 * @param file the data url
+	 * @return a PathNotFoundAction that copies the file's data if the file is not found
+	 */
+	static PathNotFoundAction copyData(Path file) {
+		// copyResource(new FIS(file)) isn't used here to avoid dealing with the exception
+		// declared by the FIS constructor
+		return f -> {
+			Files.copy(file, f);
+			return true;
+		};
+	}
+
+	/**
+	 * Action: copies the stream's data.
+	 *
+	 * @param data the stream containing the data
+	 * @return a PathNotFoundAction that copies the stream's data if the file is not found
+	 */
+	static PathNotFoundAction copyData(InputStream data) {
+		return f -> {
+			Files.copy(data, f);
+			return true;
+		};
+	}
+
+	/**
+	 * Action: copies the inner resource.
+	 *
+	 * @param resourcePath the resource's path
+	 * @return a PathNotFoundAction that copies the url's data if the file is not found
+	 *
+	 * @see Class#getResource(String)
+	 */
+	static PathNotFoundAction copyResource(String resourcePath) {
+		return copyData(PathNotFoundAction.class.getResource(resourcePath));
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/PathWatcher.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/PathWatcher.java
@@ -1,0 +1,207 @@
+package com.electronwill.nightconfig.core.path;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
+
+/**
+ * A PathWatcher can watch several files asynchronously.
+ * <p>
+ * New watches are added with the {@link #addWatch(Path, Runnable)} method, which specifies the
+ * task to execute when the file is modified.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @author TheElectronWill
+ */
+public final class PathWatcher {
+	private static final long SLEEP_TIME_NANOS = 1000;
+	private static volatile PathWatcher DEFAULT_INSTANCE;
+
+	/**
+	 * Gets the default, global instance of PathWatcher.
+	 *
+	 * @return the default PathWatcher
+	 */
+	public static synchronized PathWatcher defaultInstance() {
+		if (DEFAULT_INSTANCE == null || !DEFAULT_INSTANCE.run) {// null or stopped PathWatcher
+			DEFAULT_INSTANCE = new PathWatcher();
+		}
+		return DEFAULT_INSTANCE;
+	}
+
+	private final Map<Path, WatchedDir> watchedDirs = new ConcurrentHashMap<>();//dir -> watchService & infos
+	private final Map<Path, WatchedFile> watchedFiles = new ConcurrentHashMap<>();//file -> watchKey & handler
+	private final Thread thread = new WatcherThread();
+	private final Consumer<Exception> exceptionHandler;
+	private volatile boolean run = true;
+
+	/**
+	 * Creates a new PathWatcher. The watcher is immediately functional, there is no need (and no
+	 * way, actually) to start it manually.
+	 */
+	public PathWatcher() {
+		this(Throwable::printStackTrace);
+	}
+
+	/**
+	 * Creates a new PathWatcher. The watcher is immediately functional, there is no need (and no
+	 * way, actually) to start it manually.
+	 */
+	public PathWatcher(Consumer<Exception> exceptionHandler) {
+		this.exceptionHandler = exceptionHandler;
+		thread.start();
+	}
+
+	/**
+	 * Watches a path, if not already watched by this PathWatcher.
+	 *
+	 * @param path          the path to watch
+	 * @param changeHandler the handler to call when the path is modified
+	 */
+	public void addWatch(Path path, Runnable changeHandler) throws IOException {
+		path = path.toAbsolutePath();// Ensures that the Path is absolute
+		Path dir = path.getParent();
+		WatchedDir watchedDir = watchedDirs.computeIfAbsent(dir, k -> new WatchedDir(dir));
+		WatchKey watchKey = dir.register(watchedDir.watchService,
+										 StandardWatchEventKinds.ENTRY_MODIFY);
+		watchedFiles.computeIfAbsent(path,
+									 k -> new WatchedFile(watchedDir, watchKey, changeHandler));
+	}
+
+	/**
+	 * Watches a path. If the path is already watched by this PathWatcher, its changeHandler is
+	 * replaced.
+	 *
+	 * @param path          the path to watch
+	 * @param changeHandler the handler to call when the path is modified
+	 */
+	public void setWatch(Path path, Runnable changeHandler) throws IOException {
+		path = path.toAbsolutePath();// Ensures that the Path is absolute
+		WatchedFile watchedFile = watchedFiles.get(path);
+		if (watchedFile == null) {
+			addWatch(path, changeHandler);
+		} else {
+			watchedFile.changeHandler = changeHandler;
+		}
+	}
+
+	/**
+	 * Stops watching a path.
+	 *
+	 * @param path the path to stop watching
+	 */
+	public void removeWatch(Path path) {
+		path = path.toAbsolutePath();// Ensures that the Path is absolute
+		Path dir = path.getParent();
+		WatchedDir watchedDir = watchedDirs.get(dir);
+		int remainingChildCount = watchedDir.watchedFileCount.decrementAndGet();
+		if (remainingChildCount == 0) {
+			watchedDirs.remove(dir);
+		}
+		WatchedFile watchedFile = watchedFiles.remove(path);
+		if (watchedFile != null) {
+			watchedFile.watchKey.cancel();
+		}
+	}
+
+	/**
+	 * Stops this PathWatcher. The underlying ressources (ie the WatchServices) are closed, and
+	 * the file modification handlers won't be called anymore.
+	 */
+	public void stop() throws IOException {
+		run = false;
+	}
+
+	private final class WatcherThread extends Thread {
+		{
+			setDaemon(true);
+		}
+
+		@Override
+		public void run() {
+			while (run) {
+				boolean allNull = true;
+				dirsIter:
+				for (Iterator<WatchedDir> it = watchedDirs.values().iterator(); it.hasNext() && run; ) {
+					WatchedDir watchedDir = it.next();
+					WatchKey key = watchedDir.watchService.poll();
+					if (key == null) {
+						continue;
+					}
+					allNull = false;
+					for (WatchEvent<?> event : key.pollEvents()) {
+						if (!run) {
+							break dirsIter;
+						}
+						if (event.kind() != StandardWatchEventKinds.ENTRY_MODIFY || event.count() > 1) {
+							continue;
+						}
+						Path childPath = ((WatchEvent<Path>)event).context();
+						Path filePath = watchedDir.dir.resolve(childPath);
+						WatchedFile watchedFile = watchedFiles.get(filePath);
+						if (watchedFile != null) {
+							try {
+								watchedFile.changeHandler.run();
+							} catch (Exception e) {
+								exceptionHandler.accept(e);
+							}
+						}
+					}
+					key.reset();
+				}
+				if (allNull) {
+					LockSupport.parkNanos(SLEEP_TIME_NANOS);
+				}
+			}
+			// Closes the WatchServices
+			for (WatchedDir watchedDir : watchedDirs.values()) {
+				try {
+					watchedDir.watchService.close();
+				} catch (IOException e) {
+					exceptionHandler.accept(e);
+				}
+			}
+			// Clears the maps
+			watchedDirs.clear();
+			watchedFiles.clear();
+		}
+	}
+
+	/**
+	 * Informations about a watched directory, ie a directory that contains watched files.
+	 */
+	private static final class WatchedDir {
+		final Path dir;
+		final WatchService watchService;
+		final AtomicInteger watchedFileCount = new AtomicInteger();
+
+		private WatchedDir(Path dir) {
+			this.dir = dir;
+			try {
+				this.watchService = dir.getFileSystem().newWatchService();
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	/**
+	 * Informations about a watched file, with an associated handler.
+	 */
+	private static final class WatchedFile {
+		final WatchKey watchKey;
+		volatile Runnable changeHandler;
+
+		private WatchedFile(WatchedDir watchedDir, WatchKey watchKey, Runnable changeHandler) {
+			this.watchKey = watchKey;
+			this.changeHandler = changeHandler;
+			watchedDir.watchedFileCount.getAndIncrement();
+		}
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/SimpleCommentedPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/SimpleCommentedPathConfig.java
@@ -1,0 +1,39 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.utils.CommentedConfigWrapper;
+
+import java.nio.file.Path;
+
+/**
+ * @author TheElectronWill
+ */
+class SimpleCommentedPathConfig extends CommentedConfigWrapper<CommentedConfig>
+		implements CommentedPathConfig {
+	private final PathConfig pathConfig;
+
+	SimpleCommentedPathConfig(CommentedConfig config, PathConfig pathConfig) {
+		super(config);
+		this.pathConfig = pathConfig;
+	}
+
+	@Override
+	public Path getPath() {
+		return pathConfig.getPath();
+	}
+
+	@Override
+	public void save() {
+		pathConfig.save();
+	}
+
+	@Override
+	public void load() {
+		pathConfig.load();
+	}
+
+	@Override
+	public void close() {
+		pathConfig.close();
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/WriteAsyncPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/WriteAsyncPathConfig.java
@@ -1,0 +1,163 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.io.*;
+import com.electronwill.nightconfig.core.utils.ConfigWrapper;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.charset.Charset;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.nio.file.StandardOpenOption.*;
+
+/**
+ * @author TheElectronWill
+ */
+final class WriteAsyncPathConfig<C extends Config> extends ConfigWrapper<C> implements PathConfig {
+	private final Path path;
+	private final Charset charset;
+	/**
+	 * True if this file config has been closed.
+	 */
+	private final AtomicBoolean closed = new AtomicBoolean();
+	/**
+	 * The channel used to write asynchronously to the file.
+	 */
+	private AsynchronousFileChannel channel;
+	/**
+	 * Guards the channel to prevent it from being used and closed at the same time.
+	 */
+	private final Object channelGuard = new Object();
+	/**
+	 * True if there is a write operation in progress.
+	 */
+	private final AtomicBoolean currentlyWriting = new AtomicBoolean();
+	/**
+	 * True if the config has changed during the write operation, and thus must be written again.
+	 */
+	private final AtomicBoolean mustWriteAgain = new AtomicBoolean();
+
+	private final ConfigWriter writer;
+	private final WriteCompletedHandler writeCompletedHandler;
+	private final OpenOption[] openOptions;
+
+	private final ConfigParser<?> parser;
+	private final PathNotFoundAction nefAction;
+	private final ParsingMode parsingMode;
+
+	WriteAsyncPathConfig(C config, Path path, Charset charset, ConfigWriter writer,
+						 WritingMode writingMode, ConfigParser<?> parser,
+						 ParsingMode parsingMode, PathNotFoundAction nefAction) {
+		super(config);
+		this.path = path;
+		this.charset = charset;
+		this.writer = writer;
+		this.parser = parser;
+		this.parsingMode = parsingMode;
+		this.nefAction = nefAction;
+		if (writingMode == WritingMode.APPEND) {
+			this.openOptions = new OpenOption[]{WRITE, CREATE};
+		} else {
+			this.openOptions = new OpenOption[]{WRITE, CREATE, TRUNCATE_EXISTING};
+		}
+		this.writeCompletedHandler = new WriteCompletedHandler();
+	}
+
+	@Override
+	public Path getPath() {
+		return path;
+	}
+
+	@Override
+	public void save() {
+		if (closed.get()) {
+			throw new IllegalStateException("Cannot save a closed PathConfig");
+		}
+		save(true);
+	}
+
+	@Override
+	public void close() {
+		if (closed.compareAndSet(false, true)) {// The content of this block is called only once
+			synchronized (channelGuard) {
+				while (currentlyWriting.get()) {// Writing in progres
+					// Waits for the operation to complete, to ensure that the data is written:
+					try {
+						channelGuard.wait();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						break;// Exits from the loop and returns from the method
+					}
+				}
+			}
+		}
+	}
+
+	private void save(boolean saveLaterIfWriting) {
+		boolean canSaveNow = currentlyWriting.compareAndSet(false,
+															true);// atomically sets to true if false
+		if (canSaveNow) {// no writing is in progress: start one immediately
+			// Writes the config data to a ByteBuffer
+			CharsWrapper.Builder builder = new CharsWrapper.Builder(512);
+			writer.write(config, builder);
+			CharBuffer chars = CharBuffer.wrap(builder.build());
+			ByteBuffer buffer = charset.encode(chars);
+
+			// Writes the ByteBuffer to the file, asynchronously
+			synchronized (channelGuard) {
+				try {
+					channel = AsynchronousFileChannel.open(path, openOptions);
+					channel.write(buffer, channel.size(), null, writeCompletedHandler);
+				} catch (IOException e) {
+					writeCompletedHandler.failed(e, null);
+				}
+			}
+		} else if (saveLaterIfWriting) {// there is a writing in progress: start one later
+			mustWriteAgain.set(true);
+		}
+	}
+
+	@Override
+	public void load() {
+		if (closed.get()) {
+			throw new IllegalStateException("Cannot (re)load a closed PathConfig");
+		}
+		if (!currentlyWriting.get()) { // Skips load when writing
+			parser.parse(path, config, parsingMode, nefAction);//blocking read, not async
+		}
+	}
+
+	private final class WriteCompletedHandler implements CompletionHandler<Integer, Object> {
+		@Override
+		public void completed(Integer result, Object attachment) {
+			currentlyWriting.set(false);// Resets currentlyWriting
+			if (mustWriteAgain.getAndSet(false)) {// Gets and resets mustWriteAgain
+				save(false);// Saves the config without setting mustWriteAgain to true if canSaveNow is false
+			} else {
+				/* All operations have completed and we don't need to start a new one. Therefore
+				the channel may be closed. */
+				synchronized (channelGuard) {
+					try {
+						channel.close();
+						channel = null;
+					} catch (IOException e) {
+						failed(e, null);
+					} finally {
+						channelGuard.notify();// Notifies the waiter (if any). See method close()
+					}
+				}
+			}
+		}
+
+		@Override
+		public void failed(Throwable exc, Object attachment) {
+			throw new WritingException("Error while saving the PathConfig to " + path, exc);
+		}
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/path/WriteSyncPathConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/path/WriteSyncPathConfig.java
@@ -1,0 +1,76 @@
+package com.electronwill.nightconfig.core.path;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.io.ConfigParser;
+import com.electronwill.nightconfig.core.io.ConfigWriter;
+import com.electronwill.nightconfig.core.io.ParsingMode;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import com.electronwill.nightconfig.core.utils.ConfigWrapper;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+
+/**
+ * @author TheElectronWill
+ */
+final class WriteSyncPathConfig<C extends Config> extends ConfigWrapper<C> implements PathConfig {
+	private final Path path;
+	private final Charset charset;
+	private boolean closed;
+
+	private final ConfigWriter writer;
+	private final WritingMode writingMode;
+
+	private final ConfigParser<?> parser;
+	private final PathNotFoundAction nefAction;
+	private final ParsingMode parsingMode;
+
+	private volatile boolean currentlyWriting = false;
+
+	WriteSyncPathConfig(C config, Path path, Charset charset, ConfigWriter writer,
+						WritingMode writingMode, ConfigParser<?> parser,
+						ParsingMode parsingMode, PathNotFoundAction nefAction) {
+		super(config);
+		this.path = path;
+		this.charset = charset;
+		this.writer = writer;
+		this.parser = parser;
+		this.parsingMode = parsingMode;
+		this.nefAction = nefAction;
+		this.writingMode = writingMode;
+	}
+
+	@Override
+	public Path getPath() {
+		return path;
+	}
+
+	@Override
+	public void save() {
+		synchronized (this) {
+			if (closed) {
+				throw new IllegalStateException("Cannot save a closed PathConfig");
+			}
+			currentlyWriting = true;
+			writer.write(config, path, writingMode, charset);
+			currentlyWriting = false;
+		}
+	}
+
+	@Override
+	public void load() {
+		if (!currentlyWriting) {
+			synchronized (this) {
+				if (closed) {
+					throw new IllegalStateException("Cannot (re)load a closed PathConfig");
+				}
+				parser.parse(path, config, parsingMode, nefAction);
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		closed = true;
+	}
+}

--- a/hocon/src/main/java/com/electronwill/nightconfig/hocon/HoconFormat.java
+++ b/hocon/src/main/java/com/electronwill/nightconfig/hocon/HoconFormat.java
@@ -2,7 +2,7 @@ package com.electronwill.nightconfig.hocon;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.ConfigFormat;
-import com.electronwill.nightconfig.core.file.FormatDetector;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 import com.electronwill.nightconfig.core.io.ConfigParser;
 import com.electronwill.nightconfig.core.io.ConfigWriter;
 

--- a/json/src/main/java/com/electronwill/nightconfig/json/JsonFormat.java
+++ b/json/src/main/java/com/electronwill/nightconfig/json/JsonFormat.java
@@ -2,7 +2,7 @@ package com.electronwill.nightconfig.json;
 
 import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.ConfigFormat;
-import com.electronwill.nightconfig.core.file.FormatDetector;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 import com.electronwill.nightconfig.core.io.ConfigParser;
 import com.electronwill.nightconfig.core.io.ConfigWriter;
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TomlFormat.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TomlFormat.java
@@ -2,7 +2,7 @@ package com.electronwill.nightconfig.toml;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.ConfigFormat;
-import com.electronwill.nightconfig.core.file.FormatDetector;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 
 import java.time.temporal.Temporal;
 

--- a/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlFormat.java
+++ b/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlFormat.java
@@ -2,7 +2,7 @@ package com.electronwill.nightconfig.yaml;
 
 import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.ConfigFormat;
-import com.electronwill.nightconfig.core.file.FormatDetector;
+import com.electronwill.nightconfig.core.io.FormatDetector;
 import com.electronwill.nightconfig.core.io.ConfigParser;
 import com.electronwill.nightconfig.core.io.ConfigWriter;
 import org.yaml.snakeyaml.Yaml;


### PR DESCRIPTION
Moved FormatDetector to io package so it's shared.

Functionality seems to work OK in tests so far.

Why? Because this allows code using more advanced FileSystems functionality to work with this config library (ZipFileSystems for example).