### PR TITLE
Created module-info.java to allow proper module dependencies with java 9.

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/ConfigFormat.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/ConfigFormat.java
@@ -6,10 +6,8 @@ import com.electronwill.nightconfig.core.utils.WriterSupplier;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 /**
  * A configuration format, that can parse, create and write some types of configurations.

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/AnnotationUtils.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/AnnotationUtils.java
@@ -44,8 +44,8 @@ final class AnnotationUtils {
 			try {
 				Constructor<? extends Converter> constructor = conversion.value()
 																		 .getDeclaredConstructor();
-				if (!constructor.isAccessible()) {
-					constructor.setAccessible(true);
+				if (!constructor.trySetAccessible()) {
+					throw new ReflectionException("Unable to access constructor " + constructor);
 				}
 				return (Converter<Object, Object>)constructor.newInstance();
 			} catch (ReflectiveOperationException ex) {

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/ConversionTable.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/ConversionTable.java
@@ -14,8 +14,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
-
 /**
  * Contains conversions functions organized by value's type. A ConversionTable grows as necessary.
  *
@@ -171,10 +169,10 @@ public final class ConversionTable implements Cloneable {
 	 * @return a wrapper that converts the config's values using this conversion table.
 	 */
 	public UnmodifiableConfig wrap(UnmodifiableConfig config) {
-		return new UnmodifiableConfigWrapper<UnmodifiableConfig>(config) {
+		return new UnmodifiableConfigWrapper<>(config) {
 			@Override
 			public <T> T getRaw(List<String> path) {
-				return (T)convert(config.getRaw(path));
+				return (T) convert(config.getRaw(path));
 			}
 
 			@Override
@@ -192,7 +190,7 @@ public final class ConversionTable implements Cloneable {
 
 					@Override
 					public <T> T getRawValue() {
-						return (T)convert(entry.getRawValue());
+						return (T) convert(entry.getRawValue());
 					}
 				};
 				return new TransformingSet<>(config.entrySet(), readTransfo, o -> null, e -> e);

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectBinder.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectBinder.java
@@ -119,8 +119,8 @@ public final class ObjectBinder {
 			if (!bypassTransient && Modifier.isTransient(fieldModifiers)) {
 				continue;// Don't process transient fields if configured so
 			}
-			if (!field.isAccessible()) {
-				field.setAccessible(true);// Enforces field access if needed
+			if (!field.trySetAccessible()) { // Enforces field access if needed
+				throw new ReflectionException("Unable to access field " + field);
 			}
 			List<String> path = AnnotationUtils.getPath(field);
 			FieldInfos fieldInfos;

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectConverter.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/ObjectConverter.java
@@ -129,8 +129,8 @@ public final class ObjectConverter {
 				if (!bypassTransient && Modifier.isTransient(fieldModifiers)) {
 					continue;// Don't process transient fields if configured so
 				}
-				if (!field.isAccessible()) {
-					field.setAccessible(true);// Enforces field access if needed
+				if (!field.trySetAccessible()) { // Enforces field access if needed
+					throw new ReflectionException("Unable to access field " + field);
 				}
 
 				// --- Applies annotations ---
@@ -447,8 +447,8 @@ public final class ObjectConverter {
 	private <T> T createInstance(Class<T> tClass) {
 		try {
 			Constructor<T> ctor = tClass.getDeclaredConstructor(); // constructor without params
-			if (!ctor.isAccessible()) {
-				ctor.setAccessible(true); // forces the constructor to be accessible
+			if (!ctor.trySetAccessible()) { // forces the constructor to be accessible
+				throw new ReflectionException("Unable to make access constructor " + ctor);
 			}
 			return ctor.newInstance(); // calls the constructor
 		} catch (ReflectiveOperationException ex) {

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/CommentedFileConfigBuilder.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/CommentedFileConfigBuilder.java
@@ -5,8 +5,6 @@ import com.electronwill.nightconfig.core.ConfigFormat;
 import com.electronwill.nightconfig.core.io.ParsingMode;
 import com.electronwill.nightconfig.core.io.WritingMode;
 
-import java.io.File;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/CharsWrapper.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/CharsWrapper.java
@@ -382,7 +382,7 @@ public final class CharsWrapper implements CharSequence, Cloneable, Iterable<Cha
 
 	@Override
 	public Iterator<Character> iterator() {
-		return new Iterator<Character>() {
+		return new Iterator<>() {
 			private int index = offset;
 
 			@Override

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/ConfigWriter.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/ConfigWriter.java
@@ -5,13 +5,11 @@ import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.EnumSet;
 
 import static java.nio.file.StandardOpenOption.*;
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/ConfigWrapper.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/ConfigWrapper.java
@@ -1,7 +1,6 @@
 package com.electronwill.nightconfig.core.utils;
 
 import com.electronwill.nightconfig.core.Config;
-import com.electronwill.nightconfig.core.ConfigFormat;
 
 import java.util.List;
 import java.util.Set;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.electronwill.night.config.core {
+	exports com.electronwill.nightconfig.core;
+	exports com.electronwill.nightconfig.core.conversion;
+	exports com.electronwill.nightconfig.core.file;
+	exports com.electronwill.nightconfig.core.io;
+	exports com.electronwill.nightconfig.core.utils;
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module com.electronwill.night.config.core {
+module com.electronwill.nightconfig.core {
 	exports com.electronwill.nightconfig.core;
 	exports com.electronwill.nightconfig.core.conversion;
 	exports com.electronwill.nightconfig.core.file;

--- a/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
+++ b/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
@@ -1,6 +1,5 @@
 package com.electronwill.nightconfig.core.io;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/examples/src/main/java/AutosaveExample.java
+++ b/examples/src/main/java/AutosaveExample.java
@@ -1,6 +1,5 @@
 import com.electronwill.nightconfig.core.file.FileConfig;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 

--- a/examples/src/main/java/module-info.java
+++ b/examples/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module com.electronwill.night.config.examples {
-	requires com.electronwill.night.config.core;
-	requires com.electronwill.night.config.toml;
-	requires com.electronwill.night.config.json;
+module com.electronwill.nightconfig.examples {
+	requires com.electronwill.nightconfig.core;
+	requires com.electronwill.nightconfig.toml;
+	requires com.electronwill.nightconfig.json;
 }

--- a/examples/src/main/java/module-info.java
+++ b/examples/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.electronwill.night.config.examples {
+	requires com.electronwill.night.config.core;
+	requires com.electronwill.night.config.toml;
+	requires com.electronwill.night.config.json;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ publishReleaseUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2
 ossrhUser=dummyUser
 ossrhPassword=dummyPassword
 
-javaVersion=1.8
+javaVersion=1.11
 junitVersion=5.3.1
 snakeYamlVersion=1.23
 typesafeConfigVersion=1.3.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Feb 14 17:01:34 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/hocon/src/main/java/module-info.java
+++ b/hocon/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module com.electronwill.night.config.hocon {
+	requires transitive com.electronwill.night.config.core;
+	requires typesafe.config;
+
+	exports com.electronwill.nightconfig.hocon;
+}

--- a/hocon/src/main/java/module-info.java
+++ b/hocon/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module com.electronwill.night.config.hocon {
-	requires transitive com.electronwill.night.config.core;
+module com.electronwill.nightconfig.hocon {
+	requires transitive com.electronwill.nightconfig.core;
 	requires typesafe.config;
 
 	exports com.electronwill.nightconfig.hocon;

--- a/json/src/main/java/com/electronwill/nightconfig/json/JsonFormat.java
+++ b/json/src/main/java/com/electronwill/nightconfig/json/JsonFormat.java
@@ -15,7 +15,7 @@ import java.io.Writer;
  */
 public abstract class JsonFormat<W extends ConfigWriter> implements ConfigFormat<Config> {
 
-	private static final JsonFormat<FancyJsonWriter> FANCY = new JsonFormat<FancyJsonWriter>() {
+	private static final JsonFormat<FancyJsonWriter> FANCY = new JsonFormat<>() {
 		@Override
 		public FancyJsonWriter createWriter() {
 			return new FancyJsonWriter();
@@ -26,7 +26,7 @@ public abstract class JsonFormat<W extends ConfigWriter> implements ConfigFormat
 			return new JsonParser(this);
 		}
 	};
-	private static final JsonFormat<MinimalJsonWriter> MINIMAL = new JsonFormat<MinimalJsonWriter>() {
+	private static final JsonFormat<MinimalJsonWriter> MINIMAL = new JsonFormat<>() {
 		@Override
 		public MinimalJsonWriter createWriter() {
 			return new MinimalJsonWriter();
@@ -56,7 +56,7 @@ public abstract class JsonFormat<W extends ConfigWriter> implements ConfigFormat
 	 * @return an instance of JsonFormat with a parser that accepts empty inputs and a fancy writer
 	 */
 	public static JsonFormat<FancyJsonWriter> emptyTolerantInstance() {
-		return new JsonFormat<FancyJsonWriter>() {
+		return new JsonFormat<>() {
 			@Override
 			public FancyJsonWriter createWriter() {
 				return new FancyJsonWriter();
@@ -73,7 +73,7 @@ public abstract class JsonFormat<W extends ConfigWriter> implements ConfigFormat
 	 * @return an instance of JsonFormat with a parser that accepts empty inputs and a minimal writer
 	 */
 	public static JsonFormat<MinimalJsonWriter> minimalEmptyTolerantInstance() {
-		return new JsonFormat<MinimalJsonWriter>() {
+		return new JsonFormat<>() {
 			@Override
 			public MinimalJsonWriter createWriter() {
 				return new MinimalJsonWriter();

--- a/json/src/main/java/module-info.java
+++ b/json/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.electronwill.night.config.json {
+	requires transitive com.electronwill.night.config.core;
+
+	exports com.electronwill.nightconfig.json;
+}

--- a/json/src/main/java/module-info.java
+++ b/json/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module com.electronwill.night.config.json {
-	requires transitive com.electronwill.night.config.core;
+module com.electronwill.nightconfig.json {
+	requires transitive com.electronwill.nightconfig.core;
 
 	exports com.electronwill.nightconfig.json;
 }

--- a/json/src/test/java/com/electronwill/nightconfig/json/JsonConfigTest.java
+++ b/json/src/test/java/com/electronwill/nightconfig/json/JsonConfigTest.java
@@ -19,7 +19,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,7 +36,7 @@ public class JsonConfigTest {
 
 		config.set("string", "This is a string with a lot of characters to escape \n\r\t \\ \" ");
 		config.set("int", 123456);
-		config.set("long", 1234567890l);
+		config.set("long", 1234567890L);
 		config.set("float", 0.123456f);
 		config.set("double", 0.123456d);
 		config.set("config", config2);

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -5,7 +5,7 @@ import com.electronwill.nightconfig.core.UnmodifiableCommentedConfig;
 import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import com.electronwill.nightconfig.core.io.CharacterOutput;
 import com.electronwill.nightconfig.core.io.WritingException;
-import com.electronwill.nightconfig.core.utils.FakeUnmodifiableCommentedConfig;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/toml/src/main/java/module-info.java
+++ b/toml/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module com.electronwill.night.config.toml {
-	requires transitive com.electronwill.night.config.core;
+module com.electronwill.nightconfig.toml {
+	requires transitive com.electronwill.nightconfig.core;
 
 	exports com.electronwill.nightconfig.toml;
 }

--- a/toml/src/main/java/module-info.java
+++ b/toml/src/main/java/module-info.java
@@ -1,0 +1,5 @@
+module com.electronwill.night.config.toml {
+	requires transitive com.electronwill.night.config.core;
+
+	exports com.electronwill.nightconfig.toml;
+}

--- a/yaml/src/main/java/module-info.java
+++ b/yaml/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+module com.electronwill.night.config.yaml {
+	requires transitive com.electronwill.night.config.core;
+	requires snakeyaml;
+
+	exports com.electronwill.nightconfig.yaml;
+}

--- a/yaml/src/main/java/module-info.java
+++ b/yaml/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 module com.electronwill.night.config.yaml {
 	requires transitive com.electronwill.night.config.core;
+	requires java.sql;
 	requires snakeyaml;
 
 	exports com.electronwill.nightconfig.yaml;

--- a/yaml/src/main/java/module-info.java
+++ b/yaml/src/main/java/module-info.java
@@ -1,5 +1,5 @@
-module com.electronwill.night.config.yaml {
-	requires transitive com.electronwill.night.config.core;
+module com.electronwill.nightconfig.yaml {
+	requires transitive com.electronwill.nightconfig.core;
 	requires java.sql;
 	requires snakeyaml;
 

--- a/yaml/src/test/java/yaml/YamlTest.java
+++ b/yaml/src/test/java/yaml/YamlTest.java
@@ -1,7 +1,6 @@
 package yaml;
 
 import com.electronwill.nightconfig.core.Config;
-import com.electronwill.nightconfig.core.file.FileNotFoundAction;
 import com.electronwill.nightconfig.core.io.ParsingMode;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.electronwill.nightconfig.yaml.YamlFormat;


### PR DESCRIPTION
The point of this pull request is that the automatic naming of modules with java 9 is based on the name of the .jar of the library which in this case is `core`, `json`, ect...
So to avoid these misleading names, we can create those `module-info.java` files.

This pull request contains the addition of those files and the replacement of deprecated methods (especially the setAccessible(boolean) method).
Along with that comes some cleanup of unused imports and explicit generic when unneeded.
The android part of the repo was left untouched.

Another workaround can be to name the generated jar files in a more explicit manner like `nightconfig-core-3.4.2.jar` but it's just delaying the issue.