### PR TITLE
Add support for controlling the backing map of configs

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/CommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/CommentedConfig.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.electronwill.nightconfig.core.utils.StringUtils.split;
 
@@ -206,6 +207,17 @@ public interface CommentedConfig extends UnmodifiableCommentedConfig, Config {
 	static CommentedConfig of(ConfigFormat<? extends CommentedConfig> format) {
 		return new SimpleCommentedConfig(format, false);
 	}
+	
+	/**
+	 * Creates a Config backed by a certain kind of map, given by a supplier.
+	 *
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @param format the config's format
+	 * @return a new empty config
+	 */
+	static CommentedConfig of(Supplier<Map<String, Object>> mapCreator, ConfigFormat<? extends CommentedConfig> format) {
+		return new SimpleCommentedConfig(mapCreator, format);
+	}
 
 	/**
 	 * Creates a thread-safe CommentedConfig of the given format.
@@ -257,6 +269,20 @@ public interface CommentedConfig extends UnmodifiableCommentedConfig, Config {
 	static CommentedConfig copy(UnmodifiableConfig config) {
 		return new SimpleCommentedConfig(config, config.configFormat(), false);
 	}
+	
+	/**
+	 * Creates a new CommentedConfig with the content of the given config. The returned config will
+	 * have the same format as the copied config, and be backed by the given supplier.
+	 * 
+	 * @see #of(Supplier, ConfigFormat)
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @return a copy of the config
+	 */
+	static CommentedConfig copy(UnmodifiableConfig config, Supplier<Map<String, Object>> mapCreator) {
+		return new SimpleCommentedConfig(config, mapCreator, config.configFormat());
+	}
 
 	/**
 	 * Creates a new CommentedConfig with the content of the given config.
@@ -267,6 +293,21 @@ public interface CommentedConfig extends UnmodifiableCommentedConfig, Config {
 	 */
 	static CommentedConfig copy(UnmodifiableConfig config, ConfigFormat<?> format) {
 		return new SimpleCommentedConfig(config, format, false);
+	}
+	
+	/**
+	 * Creates a new CommentedConfig with the content of the given config. The returned config will
+	 * be backed by the given map supplier.
+	 * 
+	 * @see #of(Supplier, ConfigFormat)
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @param format the config's format
+	 * @return a copy of the config
+	 */
+	static CommentedConfig copy(UnmodifiableConfig config, Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> format) {
+		return new SimpleCommentedConfig(config, mapCreator, format);
 	}
 
 	/**
@@ -281,6 +322,18 @@ public interface CommentedConfig extends UnmodifiableCommentedConfig, Config {
 	}
 
 	/**
+	 * Creates a new CommentedConfig with the content of the given config. The returned config will
+	 * have the same format as the copied config.
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @return a copy of the config
+	 */
+	static CommentedConfig copy(UnmodifiableCommentedConfig config, Supplier<Map<String, Object>> mapCreator) {
+		return new SimpleCommentedConfig(config, mapCreator, config.configFormat());
+	}
+	
+	/**
 	 * Creates a new CommentedConfig with the content of the given config.
 	 *
 	 * @param config the config to copy
@@ -289,6 +342,21 @@ public interface CommentedConfig extends UnmodifiableCommentedConfig, Config {
 	 */
 	static CommentedConfig copy(UnmodifiableCommentedConfig config, ConfigFormat<?> format) {
 		return new SimpleCommentedConfig(config, format, false);
+	}
+	
+	/**
+	 * Creates a new CommentedConfig with the content of the given config. The returned config will
+	 * be backed by the given map supplier.
+	 * 
+	 * @see #of(Supplier, ConfigFormat)
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @param format the config's format
+	 * @return a copy of the config
+	 */
+	static CommentedConfig copy(UnmodifiableCommentedConfig config, Supplier<Map<String, Object>> mapCreator, ConfigFormat<? extends CommentedConfig> format) {
+		return new SimpleCommentedConfig(config, mapCreator, format);
 	}
 
 	/**

--- a/core/src/main/java/com/electronwill/nightconfig/core/Config.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/Config.java
@@ -1,6 +1,7 @@
 package com.electronwill.nightconfig.core;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 import static com.electronwill.nightconfig.core.utils.StringUtils.split;
 
@@ -240,6 +241,17 @@ public interface Config extends UnmodifiableConfig {
 	static Config of(ConfigFormat<? extends Config> format) {
 		return new SimpleConfig(format, false);
 	}
+	
+	/**
+	 * Creates a Config backed by a certain kind of map, given by a supplier.
+	 *
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @param format the config's format
+	 * @return a new config backed by the map
+	 */
+	static Config of(Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> format) {
+		return new SimpleConfig(mapCreator, format);
+	}
 
 	/**
 	 * Creates a thread-safe Config of the given format.
@@ -291,6 +303,20 @@ public interface Config extends UnmodifiableConfig {
 	static Config copy(UnmodifiableConfig config) {
 		return new SimpleConfig(config, config.configFormat(), false);
 	}
+	
+	/**
+	 * Creates a new Config with the content of the given config. The returned config will have
+	 * the same format as the copied config, and be backed by the given supplier.
+	 * 
+	 * @see #of(Supplier, ConfigFormat)
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @return a copy of the config
+	 */
+	static Config copy(UnmodifiableConfig config, Supplier<Map<String, Object>> mapCreator) {
+		return new SimpleConfig(config, mapCreator, config.configFormat());
+	}
 
 	/**
 	 * Creates a new Config with the content of the given config.
@@ -301,6 +327,20 @@ public interface Config extends UnmodifiableConfig {
 	 */
 	static Config copy(UnmodifiableConfig config, ConfigFormat<?> format) {
 		return new SimpleConfig(config, format, false);
+	}
+	
+	/**
+	 * Creates a new Config with the content of the given config. The returned config will be backed by the given map supplier.
+	 * 
+	 * @see #of(Supplier, ConfigFormat)
+	 *
+	 * @param config the config to copy
+	 * @param mapCreator a supplier which will be called to create all backing maps for this config (including sub-configs)
+	 * @param format the config's format
+	 * @return a copy of the config
+	 */
+	static Config copy(UnmodifiableConfig config, Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> format) {
+		return new SimpleConfig(config, mapCreator, format);
 	}
 
 	/**

--- a/core/src/main/java/com/electronwill/nightconfig/core/SimpleCommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/SimpleCommentedConfig.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 
 /**
  * Default concrete implementation of CommentedConfig. The values are stored in a map, generally a
@@ -25,11 +26,22 @@ final class SimpleCommentedConfig extends AbstractCommentedConfig {
 	}
 
 	/**
-	 * Creates a SimpleConfig with the specified data and format. The map is used as it is and
+	 * Creates a SimpleCommentedConfig with the specified data and format. The map is used as it is and
 	 * isn't copied.
 	 */
 	SimpleCommentedConfig(Map<String, Object> valueMap, ConfigFormat<?> configFormat) {
 		super(valueMap);
+		this.configFormat = configFormat;
+	}
+	
+	/**
+	 * Creates a SimpleCommentedConfig with the specified backing map supplier and format.
+	 * 
+	 * @param mapCreator the supplier for backing maps
+	 * @param configFormat the config's format
+	 */
+	SimpleCommentedConfig(Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> configFormat) {
+		super(mapCreator);
 		this.configFormat = configFormat;
 	}
 
@@ -44,6 +56,19 @@ final class SimpleCommentedConfig extends AbstractCommentedConfig {
 		super(toCopy, concurrent);
 		this.configFormat = configFormat;
 	}
+	
+	/**
+	 * Creates a SimpleCommentedConfig by copying a config, with the specified backing map creator and format.
+	 *
+	 * @param toCopy       the config to copy
+	 * @param mapCreator   the supplier for backing maps
+	 * @param configFormat the config's format
+	 */
+	public SimpleCommentedConfig(UnmodifiableConfig toCopy, Supplier<Map<String, Object>> mapCreator,
+			ConfigFormat<?> configFormat) {
+		super(toCopy, mapCreator);
+		this.configFormat = configFormat;
+	}
 
 	/**
 	 * Creates a SimpleCommentedConfig by copying a config and with the specified format.
@@ -54,6 +79,19 @@ final class SimpleCommentedConfig extends AbstractCommentedConfig {
 	SimpleCommentedConfig(UnmodifiableCommentedConfig toCopy, ConfigFormat<?> configFormat,
 						  boolean concurrent) {
 		super(toCopy, concurrent);
+		this.configFormat = configFormat;
+	}
+	
+	/**
+	 * Creates a SimpleCommentedConfig by copying a config, with the specified backing map creator and format.
+	 *
+	 * @param toCopy       the config to copy
+	 * @param mapCreator   the supplier for backing maps
+	 * @param configFormat the config's format
+	 */
+	public SimpleCommentedConfig(UnmodifiableCommentedConfig toCopy, Supplier<Map<String, Object>> mapCreator,
+			ConfigFormat<?> configFormat) {
+		super(toCopy, mapCreator);
 		this.configFormat = configFormat;
 	}
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/SimpleConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/SimpleConfig.java
@@ -1,9 +1,7 @@
 package com.electronwill.nightconfig.core;
 
-import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 
 /**
  * Default concrete implementation of Config. The values are stored in a map, generally a HashMap,
@@ -18,16 +16,43 @@ final class SimpleConfig extends AbstractConfig {
 	 * @param configFormat the config's format
 	 */
 	SimpleConfig(ConfigFormat<?> configFormat, boolean concurrent) {
-		super(concurrent ? new ConcurrentHashMap<>() : new HashMap<>());
+		super(concurrent);
+		this.configFormat = configFormat;
+	}
+	
+	/**
+	 * Creates a SimpleConfig with the specified data and format. The map is used as it is and
+	 * isn't copied.
+	 * 
+	 * @param map the data to use in the config
+	 * @param configFormat the config's format
+	 */
+	SimpleConfig(Map<String, Object> map, ConfigFormat<?> configFormat) {
+		super(map);
 		this.configFormat = configFormat;
 	}
 
 	/**
-	 * Creates a SimpleConfig with the specified data and format. The map is used as it is and
-	 * isn't copied.
+	 * Creates a SimpleConfig with the specified backing map supplier and format.
+	 * 
+	 * @param mapCreator the supplier for backing maps
+	 * @param configFormat the config's format
 	 */
-	SimpleConfig(Map<String, Object> valueMap, ConfigFormat<?> configFormat) {
-		super(valueMap);
+	SimpleConfig(Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> configFormat) {
+		super(mapCreator);
+		this.configFormat = configFormat;
+	}
+	
+	/**
+	 * Creates a SimpleConfig by copying a config.
+	 *
+	 * @param toCopy       the config to copy
+	 * @param configFormat the config's format
+	 * @param concurrent
+	 */
+	SimpleConfig(UnmodifiableConfig toCopy, ConfigFormat<?> configFormat,
+			boolean concurrent) {
+		super(toCopy, concurrent);
 		this.configFormat = configFormat;
 	}
 
@@ -35,11 +60,11 @@ final class SimpleConfig extends AbstractConfig {
 	 * Creates a SimpleConfig by copying a config.
 	 *
 	 * @param toCopy       the config to copy
+	 * @param mapCreator   the supplier for backing maps
 	 * @param configFormat the config's format
 	 */
-	SimpleConfig(UnmodifiableConfig toCopy, ConfigFormat<?> configFormat,
-				 boolean concurrent) {
-		super(toCopy, concurrent);
+	SimpleConfig(UnmodifiableConfig toCopy, Supplier<Map<String, Object>> mapCreator, ConfigFormat<?> configFormat) {
+		super(toCopy, mapCreator);
 		this.configFormat = configFormat;
 	}
 
@@ -50,11 +75,11 @@ final class SimpleConfig extends AbstractConfig {
 
 	@Override
 	public SimpleConfig createSubConfig() {
-		return new SimpleConfig(configFormat, map instanceof ConcurrentMap);
+		return new SimpleConfig(mapCreator, configFormat);
 	}
 
 	@Override
 	public SimpleConfig clone() {
-		return new SimpleConfig(this, configFormat, map instanceof ConcurrentMap);
+		return new SimpleConfig(this, mapCreator, configFormat);
 	}
 }

--- a/core/src/test/java/com/electronwill/nightconfig/core/AbstractConfigTest.java
+++ b/core/src/test/java/com/electronwill/nightconfig/core/AbstractConfigTest.java
@@ -1,10 +1,15 @@
 package com.electronwill.nightconfig.core;
 
 import com.electronwill.nightconfig.core.utils.StringUtils;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+
 import org.junit.jupiter.api.Test;
 
 import static java.lang.Math.PI;
@@ -146,5 +151,51 @@ public class AbstractConfigTest {
 		assertEquals(12, (int)config.get("int"));
 		config.remove("int");
 		assertFalse(config.contains("int"));
+	}
+	
+	@Test
+	public void backingMap() {
+		Config config = Config.of(LinkedHashMap::new, InMemoryFormat.withUniversalSupport());
+		
+		LinkedHashMap<String, String> mappings = new LinkedHashMap<>();
+		for (int i = 0; i < 26; i++) {
+			mappings.put(Character.toString((char) ('a' + i)), Character.toString((char) ('z' - i)));
+		}
+		
+		for (Entry<String, String> e : mappings.entrySet()) {
+			config.set(e.getKey(), e.getValue());
+		}
+		
+		List<Entry<String, String>> input = new ArrayList<>(mappings.entrySet());
+		List<Entry<String, Object>> output = new ArrayList<>(config.valueMap().entrySet());
+		
+		assertEquals(input.size(), output.size());
+		
+		for (int i = 0; i < input.size(); i++) {
+			assertEquals(input.get(i), output.get(i), "Map values mismatched at index: " + i);
+		}
+	}
+	
+	@Test
+	public void nestedBackingMap() {
+		Config config = Config.of(LinkedHashMap::new, InMemoryFormat.withUniversalSupport());
+		
+		LinkedHashMap<String, String> mappings = new LinkedHashMap<>();
+		for (int i = 0; i < 26; i++) {
+			mappings.put(Character.toString((char) ('a' + i)), Character.toString((char) ('z' - i)));
+		}
+		
+		for (Entry<String, String> e : mappings.entrySet()) {
+			config.set("foo." + e.getKey(), e.getValue());
+		}
+		
+		List<Entry<String, String>> input = new ArrayList<>(mappings.entrySet());
+		List<Entry<String, Object>> output = new ArrayList<>(config.<Config>get("foo").valueMap().entrySet());
+		
+		assertEquals(input.size(), output.size());
+		
+		for (int i = 0; i < input.size(); i++) {
+			assertEquals(input.get(i), output.get(i), "Map values mismatched at index: " + i);
+		}
 	}
 }


### PR DESCRIPTION
Adds a `Supplier<Map<String, Object>>` field to `AbstractConfig`, and many helper constructors/factory methods to utilize it. This allows full control over the backing map of a config object, including nested configs. Previously this was not possible, as you could only control the *initial* map object, and not nested creations of maps, making the solution recommended [here](https://github.com/TheElectronWill/Night-Config/issues/56#issuecomment-475908469) incomplete.

This partially solves #56

Needed to solve https://github.com/MinecraftForge/MinecraftForge/issues/5688