### PR TITLE
Fix NPE when a concurrent commented map encounters a null comment

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
@@ -90,8 +90,11 @@ public abstract class AbstractCommentedConfig extends AbstractConfig implements 
 	public String setComment(List<String> path, String comment) {
 		final int lastIndex = path.size() - 1;
 		final String lastKey = path.get(lastIndex);
-		if (lastIndex == 0 && comment != null) {
-			return commentMap.put(lastKey, comment);
+		if (lastIndex == 0) {
+			if (comment != null) {
+				return commentMap.put(lastKey, comment);
+			}
+			return commentMap.remove(lastKey);
 		}
 		final List<String> parentPath = path.subList(0, lastIndex);
 		Object parent = getRaw(parentPath);

--- a/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
@@ -90,7 +90,7 @@ public abstract class AbstractCommentedConfig extends AbstractConfig implements 
 	public String setComment(List<String> path, String comment) {
 		final int lastIndex = path.size() - 1;
 		final String lastKey = path.get(lastIndex);
-		if (lastIndex == 0) {
+		if (lastIndex == 0 && comment != null) {
 			return commentMap.put(lastKey, comment);
 		}
 		final List<String> parentPath = path.subList(0, lastIndex);


### PR DESCRIPTION
`AbstractCommentedConfig` can use a `ConcurrentHashMap` when the child map is concurrent, which does not support null values. From what I can tell, this change should not alter any behavior, only fix the NPE that arises when the parser encounters an entry with no comment. There's no reason for the map to contain null values.