### PR TITLE
Fix inline config writing

### DIFF
--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -25,14 +25,18 @@ final class TableWriter {
 
 	static void writeInline(UnmodifiableConfig config, CharacterOutput output, TomlWriter writer) {
 		output.write('{');
-		for (Map.Entry<String, Object> entry : config.valueMap().entrySet()) {
+		Iterator<Map.Entry<String, Object>> iterator = config.valueMap().entrySet().iterator();
+		while (iterator.hasNext()) {
+			final Map.Entry<String, Object> entry = iterator.next();
 			final String key = entry.getKey();
 			final Object value = entry.getValue();
 			// Comments aren't written in an inline table
 			writer.writeKey(key, output);
 			output.write(KEY_VALUE_SEPARATOR);
 			ValueWriter.write(value, output, writer);
-			output.write(INLINE_ENTRY_SEPARATOR);
+			if (iterator.hasNext()) {
+				output.write(INLINE_ENTRY_SEPARATOR);
+			}
 		}
 		output.write('}');
 	}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ValueWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ValueWriter.java
@@ -5,6 +5,7 @@ import com.electronwill.nightconfig.core.impl.CharacterOutput;
 import com.electronwill.nightconfig.core.io.WritingException;
 
 import java.time.temporal.Temporal;
+import java.util.Iterator;
 import java.util.List;
 
 import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
@@ -29,8 +30,13 @@ final class ValueWriter {
 		} else if (value instanceof List) {
 			List<?> list = (List<?>)value;
 			if (!list.isEmpty() && list.get(0) instanceof Config) {// Array of tables
-				for (Object table : list) {
+				Iterator<?> iterator = list.iterator();
+				while (iterator.hasNext()) {
+					final Object table = iterator.next();
 					TableWriter.writeInline((Config)table, output, writer);
+					if (iterator.hasNext()) {
+						output.write(ArrayWriter.ELEMENT_SEPARATOR);
+					}
 				}
 			} else {// Normal array
 				ArrayWriter.write((List<?>)value, output, writer);


### PR DESCRIPTION
The current implementation always adds a separator (`, `) after table `key = value` pairs even when it shouldn't (when its the last pair) and also does not add separators between list entries. This PR fixes the `TableWriter` to only put separators after pairs that are not the last pairs and fixes the `ValueWriter` to put separators after tables that are not the last table.

Current:
```toml
aConfigList = [{config0value0 = "foo", }{config1value0 = "bar", config1value1 = "baz", }{config2value0 = "fubar", config2value1 = "foobar", }]
```
Fixed:
```toml
aConfigList = [{config0value0 = "foo"}, {config1value0 = "bar", config1value1 = "baz"}, {config2value0 = "fubar", config2value1 = "foobar"}]
```