### PR TITLE
Allow java modules to have NightConfig as a dependency (Automatic-Module-Name manifest attribute)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ configure(subprojects.findAll {it.name != "examples"}) {
 		useJUnitPlatform()
 	}
 
+	jar {
+		manifest {
+			attributes "Automatic-Module-Name": "com.electronwill.nightconfig.$project.name"
+		}
+	}
+
 	task javadocJar(type: Jar, dependsOn: javadoc) {
 		archiveClassifier = 'javadoc'
 		from javadoc.destinationDir


### PR DESCRIPTION
At the moment, it's not possible to use NightConfig in a [modular application](https://www.oracle.com/corporate/features/understanding-java-9-modules.html).
This is because it does not provide a `module-info.java` file or the `Automatic-Module-Name` manifest entry.

This small PR just adds the `Automatic-Module-Name` manifest entry to the jar files to fix this problem.
Non-modular applications (for example in Java 8) will not be affected by this.
However it will allow modules (Java 9+) to have NightConfig as a dependency.