### PR TITLE
Fix config map creators not inheriting for TOML and JSON

### DIFF
--- a/json/src/main/java/com/electronwill/nightconfig/json/JsonParser.java
+++ b/json/src/main/java/com/electronwill/nightconfig/json/JsonParser.java
@@ -201,11 +201,14 @@ public final class JsonParser implements ConfigParser<Config> {
 		}
 
 		char vfirst = input.readCharAndSkip(SPACES);
-		Object value = parseValue(input, vfirst, parsingMode);
+		Object value = parseValue(input, vfirst, parsingMode, config);
 		parsingMode.put(config, key, value);
 	}
 
 	private <T> List<T> parseArray(CharacterInput input, List<T> list, ParsingMode parsingMode) {
+		return parseArray(input, list, parsingMode, null);
+	}
+	private <T> List<T> parseArray(CharacterInput input, List<T> list, ParsingMode parsingMode, Config parentConfig) {
 		boolean first = true;
 		while (true) {
 			char valueFirst = input.readCharAndSkip(SPACES);// the first character of the value
@@ -213,7 +216,7 @@ public final class JsonParser implements ConfigParser<Config> {
 				return list;
 			}
 			first = false;
-			T value = (T)parseValue(input, valueFirst, parsingMode);
+			T value = (T)parseValue(input, valueFirst, parsingMode, parentConfig);
 			list.add(value);
 			char next = input.readCharAndSkip(SPACES);// the next character, should be ']' or ','
 			if (next == ']') {// end of the array
@@ -224,14 +227,14 @@ public final class JsonParser implements ConfigParser<Config> {
 		}
 	}
 
-	private Object parseValue(CharacterInput input, char firstChar, ParsingMode parsingMode) {
+	private Object parseValue(CharacterInput input, char firstChar, ParsingMode parsingMode, Config parentConfig) {
 		switch (firstChar) {
 			case '"':
 				return parseString(input);
 			case '{':
-				return parseObject(input, configFormat.createConfig(), parsingMode);
+				return parseObject(input, parentConfig == null ? configFormat.createConfig() : parentConfig.createSubConfig(), parsingMode);
 			case '[':
-				return parseArray(input, new ArrayList<>(), parsingMode);
+				return parseArray(input, new ArrayList<>(), parsingMode, parentConfig);
 			case 't':
 				return parseTrue(input);
 			case 'f':

--- a/json/src/test/java/com/electronwill/nightconfig/json/JsonConfigTest.java
+++ b/json/src/test/java/com/electronwill/nightconfig/json/JsonConfigTest.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -211,4 +212,15 @@ public class JsonConfigTest {
 		writer.write(config, sw);
 		System.out.println("Written:\n" + sw);
 	}
+
+	@Test
+	public void testEntryOrder() {
+		FileConfig config = FileConfig.builder(file, JsonFormat.fancyInstance())
+				.preserveInsertionOrder()
+				.build();
+		config.load();
+		assertTrue(config.valueMap() instanceof LinkedHashMap);
+		assertTrue(config.<Config>get("config").valueMap() instanceof LinkedHashMap);
+	}
+
 }

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
@@ -1,5 +1,6 @@
 package com.electronwill.nightconfig.toml;
 
+import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import java.util.List;
@@ -12,7 +13,7 @@ final class ArrayParser {
 	/**
 	 * Parses a plain array, not an array of tables.
 	 */
-	static List<?> parse(CharacterInput input, TomlParser parser) {
+	static List<?> parse(CharacterInput input, TomlParser parser, Config parentConfig) {
 		List<Object> list = parser.createList();
 		while (true) {
 			char firstChar = Toml.readUsefulChar(input);
@@ -28,7 +29,7 @@ final class ArrayParser {
 										   + "' - "
 										   + "Expected end of array because of the leading comma.");
 			}
-			Object value = ValueParser.parse(input, firstChar, parser);
+			Object value = ValueParser.parse(input, firstChar, parser, parentConfig);
 			list.add(value);
 			char after = Toml.readUsefulChar(input);
 			if (after == ']') {// End of the array

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
@@ -1,6 +1,6 @@
 package com.electronwill.nightconfig.toml;
 
-import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import java.util.List;
@@ -13,7 +13,7 @@ final class ArrayParser {
 	/**
 	 * Parses a plain array, not an array of tables.
 	 */
-	static List<?> parse(CharacterInput input, TomlParser parser, Config parentConfig) {
+	static List<?> parse(CharacterInput input, TomlParser parser, CommentedConfig parentConfig) {
 		List<Object> list = parser.createList();
 		while (true) {
 			char firstChar = Toml.readUsefulChar(input);

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableParser.java
@@ -1,6 +1,7 @@
 package com.electronwill.nightconfig.toml;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.CharsWrapper;
 import com.electronwill.nightconfig.core.io.ParsingException;
@@ -17,8 +18,8 @@ final class TableParser {
 
 	private static final char[] KEY_END = {'\t', ' ', '=', '.', '\n', '\r', ']', ':'};
 
-	static CommentedConfig parseInline(CharacterInput input, TomlParser parser) {
-		CommentedConfig config = TomlFormat.instance().createConfig();
+	static CommentedConfig parseInline(CharacterInput input, TomlParser parser, Config parentConfig) {
+		CommentedConfig config = CommentedConfig.fake(parentConfig.createSubConfig());
 		while (true) {
 			char keyFirst = Toml.readNonSpaceChar(input, false);
 			if (keyFirst == '}') {
@@ -28,7 +29,7 @@ final class TableParser {
 			char sep = Toml.readNonSpaceChar(input, false);
 			checkInvalidSeparator(sep, key, parser);
 
-			Object value = ValueParser.parse(input, parser);
+			Object value = ValueParser.parse(input, parser, parentConfig);
 			Object previous = parser.getParsingMode().put(config.valueMap(), key, value);
 			checkDuplicateKey(key, previous, true);
 
@@ -54,7 +55,7 @@ final class TableParser {
 			}
 			List<String> key = parseDottedKey(input, (char)keyFirst, parser);
 
-			Object value = ValueParser.parse(input, parser);
+			Object value = ValueParser.parse(input, parser, config);
 			Object previous = parser.getParsingMode().put(config, key, value);
 			checkDuplicateKey(key, previous, parser.configWasEmpty());
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableParser.java
@@ -1,7 +1,6 @@
 package com.electronwill.nightconfig.toml;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
-import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.CharsWrapper;
 import com.electronwill.nightconfig.core.io.ParsingException;
@@ -18,8 +17,8 @@ final class TableParser {
 
 	private static final char[] KEY_END = {'\t', ' ', '=', '.', '\n', '\r', ']', ':'};
 
-	static CommentedConfig parseInline(CharacterInput input, TomlParser parser, Config parentConfig) {
-		CommentedConfig config = CommentedConfig.fake(parentConfig.createSubConfig());
+	static CommentedConfig parseInline(CharacterInput input, TomlParser parser, CommentedConfig parentConfig) {
+		CommentedConfig config = parentConfig.createSubConfig();
 		while (true) {
 			char keyFirst = Toml.readNonSpaceChar(input, false);
 			if (keyFirst == '}') {

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
@@ -69,7 +69,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 											   + " because of an invalid "
 											   + "parent that isn't a table.");
 				}
-				CommentedConfig table = TableParser.parseNormal(input, this);
+				CommentedConfig table = TableParser.parseNormal(input, this, CommentedConfig.fake(parentConfig.createSubConfig()));
 				List<CommentedConfig> arrayOfTables = (List)parentMap.get(lastKey);
 				if (arrayOfTables == null) {
 					arrayOfTables = createList();
@@ -85,7 +85,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 				}
 				Object alreadyDeclared = parentMap.get(lastKey);
 				if (alreadyDeclared == null) {
-					CommentedConfig table = TableParser.parseNormal(input, this);
+					CommentedConfig table = TableParser.parseNormal(input, this, CommentedConfig.fake(parentConfig.createSubConfig()));
 					parentMap.put(lastKey, table);
 				} else {
 					if (alreadyDeclared instanceof Config) {
@@ -110,7 +110,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 		for (String key : path) {
 			Object value = currentConfig.valueMap().get(key);
 			if (value == null) {
-				Config sub = TomlFormat.instance().createConfig();
+				Config sub = parentTable.createSubConfig();
 				currentConfig.valueMap().put(key, sub);
 				currentConfig = sub;
 			} else if (value instanceof Config) {

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ValueParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ValueParser.java
@@ -1,6 +1,6 @@
 package com.electronwill.nightconfig.toml;
 
-import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.CommentedConfig;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.CharsWrapper;
 import com.electronwill.nightconfig.core.io.ParsingException;
@@ -25,7 +25,7 @@ final class ValueParser {
 	 * Parses a TOML value. The value's type is determinated with the first character, and with
 	 * the next ones if necessary.
 	 */
-	static Object parse(CharacterInput input, char firstChar, TomlParser parser, Config parentConfig) {
+	static Object parse(CharacterInput input, char firstChar, TomlParser parser, CommentedConfig parentConfig) {
 		switch (firstChar) {
 			case '{':
 				return TableParser.parseInline(input, parser, parentConfig);
@@ -65,7 +65,7 @@ final class ValueParser {
 		}
 	}
 
-	static Object parse(CharacterInput input, TomlParser parser, Config parentConfig) {
+	static Object parse(CharacterInput input, TomlParser parser, CommentedConfig parentConfig) {
 		return parse(input, Toml.readNonSpaceChar(input, false), parser, parentConfig);
 	}
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ValueParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ValueParser.java
@@ -1,5 +1,6 @@
 package com.electronwill.nightconfig.toml;
 
+import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.io.CharacterInput;
 import com.electronwill.nightconfig.core.io.CharsWrapper;
 import com.electronwill.nightconfig.core.io.ParsingException;
@@ -24,12 +25,12 @@ final class ValueParser {
 	 * Parses a TOML value. The value's type is determinated with the first character, and with
 	 * the next ones if necessary.
 	 */
-	static Object parse(CharacterInput input, char firstChar, TomlParser parser) {
+	static Object parse(CharacterInput input, char firstChar, TomlParser parser, Config parentConfig) {
 		switch (firstChar) {
 			case '{':
-				return TableParser.parseInline(input, parser);
+				return TableParser.parseInline(input, parser, parentConfig);
 			case '[':
-				return ArrayParser.parse(input, parser);
+				return ArrayParser.parse(input, parser, parentConfig);
 			case '\'':
 				if (input.peek() == '\'' && input.peek(1) == '\'') {
 					input.skipPeeks();// Don't include the opening quotes in the String
@@ -64,8 +65,8 @@ final class ValueParser {
 		}
 	}
 
-	static Object parse(CharacterInput input, TomlParser parser) {
-		return parse(input, Toml.readNonSpaceChar(input, false), parser);
+	static Object parse(CharacterInput input, TomlParser parser, Config parentConfig) {
+		return parse(input, Toml.readNonSpaceChar(input, false), parser, parentConfig);
 	}
 
 	private static boolean shouldBeTemporal(CharsWrapper valueChars) {

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
@@ -1,14 +1,19 @@
 package com.electronwill.nightconfig.toml;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.Config;
 import com.electronwill.nightconfig.core.TestEnum;
 import com.electronwill.nightconfig.core.file.FileNotFoundAction;
 import com.electronwill.nightconfig.core.io.ParsingException;
+import com.electronwill.nightconfig.core.io.ParsingMode;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -44,6 +49,18 @@ public class TomlParserTest {
 		CommentedConfig reparsed = new TomlParser().parse(new StringReader(sw.toString()));
 		System.out.println("--- reparsed --- \n" + reparsed);
 		assertEquals(parsed, reparsed);
+	}
+
+	@Test
+	public void testIterationOrder() {
+		File file = new File("test.toml");
+		CommentedConfig parsed = TomlFormat.newConfig(Config.getDefaultMapCreator(false, true));
+		new TomlParser().parse(file, parsed, ParsingMode.MERGE, FileNotFoundAction.THROW_ERROR);
+		assertTrue(parsed.valueMap() instanceof LinkedHashMap);
+		assertTrue(parsed.<CommentedConfig>get("inline_table").valueMap() instanceof LinkedHashMap);
+		assertTrue(parsed.<CommentedConfig>get("table").valueMap() instanceof LinkedHashMap);
+		assertTrue(parsed.<CommentedConfig>get("table").<CommentedConfig>get("subTable").valueMap() instanceof LinkedHashMap);
+		assertTrue(parsed.<CommentedConfig>get("array").<List<CommentedConfig>>get("ofTables").get(0).valueMap() instanceof LinkedHashMap);
 	}
 
 	@Test


### PR DESCRIPTION
This causes child configs to not preserve iteration order, even though it has been set for their parent.
This fixes #85, at least for TOML and JSON. For Hocon it is not easily possible, because the underlying library Typesafe Config always uses a plain HashMap and this behavior is not configurable.

I've also added tests for TOML and JSON to test this behavior.