### PR TITLE
Fix #101 and Problems Arrays of Inline Tables

### DIFF
--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -64,7 +64,7 @@ final class TableWriter {
 				continue;
 			} else if (value instanceof List) {
 				List<?> list = (List<?>)value;
-				if (!list.isEmpty() && list.get(0) instanceof UnmodifiableConfig) {
+				if (!list.isEmpty() && list.stream().allMatch(UnmodifiableConfig.class::isInstance)) {
 					tableArraysEntries.add(entry);
 					continue;
 				}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TomlFormat.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TomlFormat.java
@@ -70,6 +70,6 @@ public final class TomlFormat implements ConfigFormat<CommentedConfig> {
 
 	@Override
 	public boolean supportsType(Class<?> type) {
-		return ConfigFormat.super.supportsType(type) || Temporal.class.isAssignableFrom(type);
+		return type != null && (ConfigFormat.super.supportsType(type) || Temporal.class.isAssignableFrom(type));
 	}
 }

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
@@ -117,7 +117,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 				currentConfig = (Config)value;
 			} else if (value instanceof List) {
 				List<?> list = (List<?>)value;
-				if (!list.isEmpty() && list.get(0) instanceof Config) {// Arrays of tables
+				if (!list.isEmpty() && list.stream().allMatch(Config.class::isInstance)) {// Arrays of tables
 					int lastIndex = list.size() - 1;
 					currentConfig = (Config)list.get(lastIndex);
 				} else {

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ValueWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ValueWriter.java
@@ -29,7 +29,7 @@ final class ValueWriter {
 			TableWriter.writeInline((Config)value, output, writer);
 		} else if (value instanceof List) {
 			List<?> list = (List<?>)value;
-			if (!list.isEmpty() && list.get(0) instanceof Config) {// Array of tables
+			if (!list.isEmpty() && list.stream().allMatch(Config.class::isInstance)) {// Array of tables
 				Iterator<?> iterator = list.iterator();
 				while (iterator.hasNext()) {
 					final Object table = iterator.next();

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlFormatTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlFormatTest.java
@@ -1,0 +1,12 @@
+package com.electronwill.nightconfig.toml;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TomlFormatTest {
+
+	@Test
+	public void noNulls() {
+		Assertions.assertFalse(TomlFormat.instance().supportsType(null));
+	}
+}

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
@@ -74,7 +74,8 @@ public class TomlParserTest {
 		assertThrows(ParsingException.class, this::testInvalidTableDeclaration7);
 		assertThrows(ParsingException.class, this::testInvalidTableArrayDeclaration);
 		assertThrows(ParsingException.class, this::testInvalidTableArrayDeclaration2);
-		assertThrows(ParsingException.class, this::testMixedArraySubtable);
+		assertThrows(ParsingException.class, this::testMixedArraySubtableTable);
+		assertThrows(ParsingException.class, this::testMixedArraySubtablePrimitive);
 		assertThrows(ParsingException.class, this::testInlineTableArraySubtable);
 	}
 
@@ -183,8 +184,15 @@ public class TomlParserTest {
 		parseAndPrint(toml);
 	}
 
-	private void testMixedArraySubtable() {
+	private void testMixedArraySubtableTable() {
 		String toml = "array = [{}, 42, {}]\n"
+			+ "[array.subtable]\n"
+			+ "   test = 'success'\n";
+		parseAndPrint(toml);
+	}
+
+	private void testMixedArraySubtablePrimitive() {
+		String toml = "array = [{}, 42]\n"
 			+ "[array.subtable]\n"
 			+ "   test = 'success'\n";
 		parseAndPrint(toml);

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlParserTest.java
@@ -74,6 +74,8 @@ public class TomlParserTest {
 		assertThrows(ParsingException.class, this::testInvalidTableDeclaration7);
 		assertThrows(ParsingException.class, this::testInvalidTableArrayDeclaration);
 		assertThrows(ParsingException.class, this::testInvalidTableArrayDeclaration2);
+		assertThrows(ParsingException.class, this::testMixedArraySubtable);
+		assertThrows(ParsingException.class, this::testInlineTableArraySubtable);
 	}
 
 	private void testAlreadyDefinedTable() {
@@ -181,4 +183,17 @@ public class TomlParserTest {
 		parseAndPrint(toml);
 	}
 
+	private void testMixedArraySubtable() {
+		String toml = "array = [{}, 42, {}]\n"
+			+ "[array.subtable]\n"
+			+ "   test = 'success'\n";
+		parseAndPrint(toml);
+	}
+
+	private void testInlineTableArraySubtable() {
+		String toml = "array = [{}, {}]\n"
+			+ "[array.subtable]\n"
+			+ "   test = 'success'\n";
+		parseAndPrint(toml);
+	}
 }

--- a/toml/test.toml
+++ b/toml/test.toml
@@ -27,6 +27,7 @@ multilineArray = [
 mixed_array = [0, 1.0]
 mixed_array2 = ["a", ["b"]]
 mixed_array3 = [true, 0x1, "c"]
+mixed_array_with_inline_tables = [{"a" = true}, "b", {"c" = 42}, "d"]
 
 basicMultiline = """
 First line


### PR DESCRIPTION
Fixes #101 by returning `false` in `TomlFormat.supportsType` when the argument is `null`.
Added a Testcase for this.

After some poking i additionally noticed that arrays containing inline tables are not handled well.
* If an Arrays starts with an inline table it is treated as an array of tables and leads to ClassCastExceptions being thrown. (see example1 below; fixed in `TomlWriter` and `TableWriter`, testcase added to test.toml)
* `TomlParser` is similiar and treats such lists as array of tables, and as such allows the usage of subtables. This is contrary to the TOML spec that states "Inline tables are fully self-contained and define all keys and sub-tables within them. Keys and sub-tables cannot be added outside the braces." 
    * In example2 and example4 this leads to the key test being added to the last element of the Array
    * In example3 this leads to a ClassCastExcpetion
    * example2 and example3 are fixed in `TomlParser` and testcases were added to `TomlParserTest`
    * a **failing testcase** was added for example4. I do not see how to fix this without a major redesign because as there is no way to differentiate an array of tables from an array of inline tables.

```toml
example1 = [{}, 42]

example2 = [{}, 42, {}]
[exmaple2.subtable]
test = "success"

example3 = [{}, 42]
[exmaple3.subtable]
test = "success"

example4 = [{}, {}]
[exmaple4.subtable]
test = "success"
```