### PR TITLE
Parse and write configs inside collections correctly for yaml

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingCollection.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingCollection.java
@@ -20,10 +20,10 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings("unchecked")
 public class TransformingCollection<InternalV, ExternalV> implements Collection<ExternalV> {
-	private final Function<? super InternalV, ? extends ExternalV> readTransformation;
-	private final Function<? super ExternalV, ? extends InternalV> writeTransformation;
-	private final Function<Object, Object> searchTransformation;
-	private final Collection<InternalV> internalCollection;
+	protected final Function<? super InternalV, ? extends ExternalV> readTransformation;
+	protected final Function<? super ExternalV, ? extends InternalV> writeTransformation;
+	protected final Function<Object, Object> searchTransformation;
+	protected final Collection<InternalV> internalCollection;
 
 	public TransformingCollection(Collection<InternalV> internalCollection,
 								  Function<? super InternalV, ? extends ExternalV> readTransformation,
@@ -86,20 +86,20 @@ public class TransformingCollection<InternalV, ExternalV> implements Collection<
 	@Override
 	public boolean containsAll(Collection<?> c) {
 		return internalCollection.containsAll(
-				new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
+			new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
 	}
 
 	@Override
 	public boolean addAll(Collection<? extends ExternalV> c) {
 		return internalCollection.addAll(
-				new TransformingCollection(c, writeTransformation, readTransformation,
-										   searchTransformation));
+			new TransformingCollection(c, writeTransformation, readTransformation,
+				searchTransformation));
 	}
 
 	@Override
 	public boolean removeAll(Collection<?> c) {
 		return internalCollection.removeAll(
-				new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
+			new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
 	}
 
 	@Override
@@ -111,7 +111,7 @@ public class TransformingCollection<InternalV, ExternalV> implements Collection<
 	@Override
 	public boolean retainAll(Collection<?> c) {
 		return internalCollection.retainAll(
-				new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
+			new TransformingCollection(c, searchTransformation, o -> o, searchTransformation));
 	}
 
 	@Override
@@ -138,5 +138,20 @@ public class TransformingCollection<InternalV, ExternalV> implements Collection<
 	@Override
 	public void forEach(Consumer<? super ExternalV> action) {
 		internalCollection.forEach(internalV -> action.accept(readTransformation.apply(internalV)));
+	}
+
+	@Override
+	public int hashCode() {
+		return internalCollection.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return internalCollection.equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return internalCollection.toString();
 	}
 }

--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingIterator.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingIterator.java
@@ -14,9 +14,9 @@ import java.util.function.Function;
  * @author TheElectronWill
  * @see TransformingMap
  */
-public final class TransformingIterator<InternalV, ExternalV> implements Iterator<ExternalV> {
-	private final Function<? super InternalV, ? extends ExternalV> readTransformation;
-	private final Iterator<InternalV> internalIterator;
+public class TransformingIterator<InternalV, ExternalV> implements Iterator<ExternalV> {
+	protected final Function<? super InternalV, ? extends ExternalV> readTransformation;
+	protected final Iterator<InternalV> internalIterator;
 
 	public TransformingIterator(Iterator<InternalV> internalIterator,
 								Function<? super InternalV, ? extends ExternalV> readTransformation) {
@@ -43,5 +43,20 @@ public final class TransformingIterator<InternalV, ExternalV> implements Iterato
 	public void forEachRemaining(Consumer<? super ExternalV> action) {
 		internalIterator.forEachRemaining(
 				internalV -> action.accept(readTransformation.apply(internalV)));
+	}
+
+	@Override
+	public int hashCode() {
+		return internalIterator.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return internalIterator.equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return internalIterator.toString();
 	}
 }

--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingList.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingList.java
@@ -1,0 +1,68 @@
+package com.electronwill.nightconfig.core.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.function.Function;
+
+public final class TransformingList<InternalV, ExternalV>
+	    extends TransformingCollection<InternalV, ExternalV> implements List<ExternalV> {
+	public TransformingList(List<InternalV> internalList,
+							Function<? super InternalV, ? extends ExternalV> readTransformation,
+							Function<? super ExternalV, ? extends InternalV> writeTransformation,
+							Function<Object, Object> searchTransformation) {
+		super(internalList, readTransformation, writeTransformation, searchTransformation);
+	}
+
+	@Override
+	public boolean addAll(int index, Collection<? extends ExternalV> c) {
+		return ((List<InternalV>) internalCollection).addAll(index,
+			new TransformingCollection(c, writeTransformation, readTransformation, searchTransformation));
+	}
+
+	@Override
+	public ExternalV get(int index) {
+		return readTransformation.apply(((List<InternalV>) internalCollection).get(index));
+	}
+
+	@Override
+	public ExternalV set(int index, ExternalV element) {
+		return readTransformation.apply(((List<InternalV>) internalCollection).set(index, writeTransformation.apply(element)));
+	}
+
+	@Override
+	public void add(int index, ExternalV element) {
+		((List<InternalV>) internalCollection).add(index, writeTransformation.apply(element));
+	}
+
+	@Override
+	public ExternalV remove(int index) {
+		return readTransformation.apply(((List<InternalV>) internalCollection).remove(index));
+	}
+
+	@Override
+	public int indexOf(Object o) {
+		return ((List<InternalV>) internalCollection).indexOf(searchTransformation.apply(o));
+	}
+
+	@Override
+	public int lastIndexOf(Object o) {
+		return ((List<InternalV>) internalCollection).lastIndexOf(searchTransformation.apply(o));
+	}
+
+	@Override
+	public ListIterator<ExternalV> listIterator() {
+		return new TransformingListIterator<>(((List<InternalV>) internalCollection).listIterator(), readTransformation, writeTransformation);
+	}
+
+	@Override
+	public ListIterator<ExternalV> listIterator(int index) {
+		return new TransformingListIterator<>(((List<InternalV>) internalCollection).listIterator(index), readTransformation, writeTransformation);
+	}
+
+	@Override
+	public List<ExternalV> subList(int fromIndex, int toIndex) {
+		return new TransformingList<>(((List<InternalV>) internalCollection).subList(fromIndex, toIndex),
+			readTransformation, writeTransformation, searchTransformation);
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingListIterator.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingListIterator.java
@@ -1,0 +1,46 @@
+package com.electronwill.nightconfig.core.utils;
+
+import java.util.ListIterator;
+import java.util.function.Function;
+
+public final class TransformingListIterator<InternalV, ExternalV>
+	    extends TransformingIterator<InternalV, ExternalV> implements ListIterator<ExternalV> {
+	private final Function<? super ExternalV, ? extends InternalV> writeTransformation;
+
+	public TransformingListIterator(ListIterator<InternalV> internalIterator,
+									Function<? super InternalV, ? extends ExternalV> readTransformation,
+									Function<? super ExternalV, ? extends InternalV> writeTransformation) {
+		super(internalIterator, readTransformation);
+		this.writeTransformation = writeTransformation;
+	}
+
+	@Override
+	public boolean hasPrevious() {
+		return ((ListIterator<InternalV>) internalIterator).hasPrevious();
+	}
+
+	@Override
+	public ExternalV previous() {
+		return readTransformation.apply(((ListIterator<InternalV>) internalIterator).previous());
+	}
+
+	@Override
+	public int nextIndex() {
+		return ((ListIterator<InternalV>) internalIterator).nextIndex();
+	}
+
+	@Override
+	public int previousIndex() {
+		return ((ListIterator<InternalV>) internalIterator).previousIndex();
+	}
+
+	@Override
+	public void set(ExternalV externalV) {
+		((ListIterator<InternalV>) internalIterator).set(writeTransformation.apply(externalV));
+	}
+
+	@Override
+	public void add(ExternalV externalV) {
+		((ListIterator<InternalV>) internalIterator).add(writeTransformation.apply(externalV));
+	}
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingSpliterator.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/utils/TransformingSpliterator.java
@@ -72,4 +72,19 @@ public final class TransformingSpliterator<InternalV, ExternalV> implements Spli
 											  .compare(writeTransformation.apply(o1),
 													   writeTransformation.apply(o2));
 	}
+
+	@Override
+	public int hashCode() {
+		return internalSpliterator.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return internalSpliterator.equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return internalSpliterator.toString();
+	}
 }

--- a/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlParser.java
+++ b/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlParser.java
@@ -5,11 +5,13 @@ import com.electronwill.nightconfig.core.ConfigFormat;
 import com.electronwill.nightconfig.core.io.ConfigParser;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import com.electronwill.nightconfig.core.io.ParsingMode;
+import com.electronwill.nightconfig.core.utils.TransformingList;
 import com.electronwill.nightconfig.core.utils.TransformingMap;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.Reader;
+import java.util.List;
 import java.util.Map;
 
 import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
@@ -70,10 +72,17 @@ public final class YamlParser implements ConfigParser<Config> {
 		return new TransformingMap<>(map, this::wrap, v -> v, v -> v);
 	}
 
+	private List<Object> wrapList(List<Object> list) {
+		return new TransformingList<>(list, this::wrap, v -> v, v -> v);
+	}
+
 	private Object wrap(Object value) {
 		if (value instanceof Map) {
 			Map<String, Object> map = wrap((Map)value);
 			return Config.wrap(map, configFormat);
+		}
+		if (value instanceof List) {
+			return (List<Object>) wrapList((List)value);
 		}
 		if (value == null) {
 			return NULL_OBJECT;

--- a/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlWriter.java
+++ b/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlWriter.java
@@ -3,11 +3,13 @@ package com.electronwill.nightconfig.yaml;
 import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import com.electronwill.nightconfig.core.io.ConfigWriter;
 import com.electronwill.nightconfig.core.io.WritingException;
+import com.electronwill.nightconfig.core.utils.TransformingList;
 import com.electronwill.nightconfig.core.utils.TransformingMap;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.Writer;
+import java.util.List;
 import java.util.Map;
 
 import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
@@ -46,9 +48,16 @@ public final class YamlWriter implements ConfigWriter {
 		return new TransformingMap<>(config.valueMap(), YamlWriter::unwrap, v -> v, v -> v);
 	}
 
+	private static List<Object> unwrapList(List<Object> list) {
+		return new TransformingList<>(list, YamlWriter::unwrap, v -> v, v -> v);
+	}
+
 	private static Object unwrap(Object value) {
 		if (value instanceof UnmodifiableConfig) {
 			return unwrap((UnmodifiableConfig)value);
+		}
+		if (value instanceof List) {
+			return unwrapList((List<Object>)value);
 		}
 		if (value == NULL_OBJECT) {
 			return null;

--- a/yaml/src/test/java/yaml/YamlTest.java
+++ b/yaml/src/test/java/yaml/YamlTest.java
@@ -2,17 +2,16 @@ package yaml;
 
 import com.electronwill.nightconfig.core.BasicTestEnum;
 import com.electronwill.nightconfig.core.Config;
-import com.electronwill.nightconfig.core.TestEnum;
-import com.electronwill.nightconfig.core.file.FileNotFoundAction;
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
 import com.electronwill.nightconfig.core.io.ParsingMode;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.electronwill.nightconfig.yaml.YamlFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.yaml.snakeyaml.TypeDescription;
-import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
 import static com.electronwill.nightconfig.core.file.FileNotFoundAction.THROW_ERROR;
@@ -25,12 +24,18 @@ public class YamlTest {
 	@Test
 	public void testReadWrite() {
 		Config config = Config.inMemory();
+		Config config1 = Config.inMemory();
+		Config config2 = Config.inMemory();
+		config1.set("foo", "bar");
+		config2.set("baz", true);
 		config.set("null", null);
 		config.set("nullObject", NULL_OBJECT);
 		config.set("string", "this is a string");
 		config.set("sub.null", null);
 		config.set("sub.nullObject", NULL_OBJECT);
 		config.set("enum", BasicTestEnum.A); // complex enums doesn't appear to work with SnakeYAML
+		config.set("list", Arrays.asList(10, 12));
+		config.set("objectList", Arrays.asList(config1, config2));
 
 		System.out.println("Config: " + config);
 		System.out.println("classOf[sub] = " + config.get("sub").getClass());
@@ -48,6 +53,8 @@ public class YamlTest {
 		assertSame(NULL_OBJECT, parsed.valueMap().get("null"));
 		assertSame(NULL_OBJECT,	parsed.valueMap().get("nullObject"));
 		assertEquals(BasicTestEnum.A, parsed.getEnum("enum", BasicTestEnum.class));
+		assertEquals(12, parsed.<List<Integer>>get("list").get(1));
+		assertEquals(Boolean.TRUE, parsed.<List<UnmodifiableConfig>>get("objectList").get(1).get("baz"));
 
 		Assertions.assertEquals(config, parsed, "Error: written != parsed");
 	}

--- a/yaml/test.yml
+++ b/yaml/test.yml
@@ -2,4 +2,8 @@ sub: {'null': null, nullObject: null}
 'null': null
 string: this is a string
 nullObject: null
+list: [10, 12]
 enum: !!com.electronwill.nightconfig.core.BasicTestEnum 'A'
+objectList:
+- {foo: bar}
+- {baz: true}


### PR DESCRIPTION
This will wrap the contents of `List` elements returned by SnakeYAML correctly, mostly to help with wrapping `Config`s inside those lists. I've also added an example to the unit tests.

I also simplified some the `TransformingCollection` classes to use their `AbstractCollection` counterparts more.