### PR TITLE
Reduce excessive (1mil/s) file watcher frequency

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
  * @author TheElectronWill
  */
 public final class FileWatcher {
-	private static final long SLEEP_TIME_NANOS = 1000;
+	private static final long SLEEP_TIME_MILLIS = 1000;
 	private static volatile FileWatcher DEFAULT_INSTANCE;
 
 	/**
@@ -187,7 +187,11 @@ public final class FileWatcher {
 					key.reset();
 				}
 				if (allNull) {
-					LockSupport.parkNanos(SLEEP_TIME_NANOS);
+					try {
+						Thread.sleep(SLEEP_TIME_MILLIS);
+					} catch (InterruptedException e) {
+						run = false;
+					}
 				}
 			}
 			// Closes the WatchServices


### PR DESCRIPTION
It looks like the FileWatcher is intended to sleep for 1 second (1000ms) before re-checking watched files, but it actually sleeps for 1000ns - so it checks watched files up to 1 million times every second! This causes a fair amount of excessive CPU load, even while the process is idle.

Renamed `SLEEP_TIME_NANOS` to `SLEEP_TIME_MILLIS`, and changed from `parkNanos` to `Thread.sleep` - high resolution is not required, and this allows the watcher thread to be interrupted to shut it down.

Unscientific comparison of a Minecraft server; before:
![image](https://github.com/TheElectronWill/night-config/assets/1138417/65051d8b-fb56-4a06-a0c5-6c6f4b2d99e9)
After:
![image](https://github.com/TheElectronWill/night-config/assets/1138417/6bd24a45-ae67-4d6f-8a62-9f481bc86edd)
