### PR TITLE
Optimize the file watcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+# Java Gradle CircleCI 2.0 configuration file
+# See: https://circleci.com/docs/language-java/
+version: 2
+
+jobs:
+  build:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      # specify the version you desire here
+      - image: cimg/openjdk:11.0
+
+    working_directory: ~/repo
+
+    # Add steps to the job
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+
+      # run tests!
+      - run: gradle test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: java
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'biz.aQute.bnd.builder' version '6.3.1' apply false
+    id 'biz.aQute.bnd.builder' version '6.4.0' apply false
 }
 
 configure(subprojects.findAll {it.name != "examples"}) {
@@ -24,6 +24,10 @@ configure(subprojects.findAll {it.name != "examples"}) {
 
 	test {
 		useJUnitPlatform()
+		testLogging {
+			showStackTraces true
+			showStandardStreams true
+		}
 	}
 
 	dependencies {

--- a/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/AbstractCommentedConfig.java
@@ -3,7 +3,6 @@ package com.electronwill.nightconfig.core;
 import com.electronwill.nightconfig.core.utils.TransformingSet;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
@@ -20,7 +19,7 @@ public abstract class AbstractCommentedConfig extends AbstractConfig implements 
 		super(concurrent);
 		this.commentMap = getDefaultCommentMap(concurrent);
 	}
-	
+
 	public AbstractCommentedConfig(Supplier<Map<String, Object>> mapCreator) {
 		super(mapCreator);
 		this.commentMap = AbstractConfig.<String>getWildcardMapCreator(mapCreator).get();
@@ -45,7 +44,7 @@ public abstract class AbstractCommentedConfig extends AbstractConfig implements 
 		super(toCopy, concurrent);
 		this.commentMap = getDefaultCommentMap(concurrent);
 	}
-	
+
 	public AbstractCommentedConfig(UnmodifiableConfig toCopy, Supplier<Map<String, Object>> mapCreator) {
 		super(toCopy, mapCreator);
 		this.commentMap = AbstractConfig.<String>getWildcardMapCreator(mapCreator).get();
@@ -61,12 +60,12 @@ public abstract class AbstractCommentedConfig extends AbstractConfig implements 
 		this.commentMap = getDefaultCommentMap(concurrent);
 		this.commentMap.putAll(toCopy.commentMap());
 	}
-	
+
 	public AbstractCommentedConfig(UnmodifiableCommentedConfig toCopy, Supplier<Map<String, Object>> mapCreator) {
 		super(toCopy, mapCreator);
 		this.commentMap = AbstractConfig.<String>getWildcardMapCreator(mapCreator).get();
 	}
-	
+
 	protected static Map<String, String> getDefaultCommentMap(boolean concurrent) {
 		return AbstractConfig.<String>getDefaultMapCreator(concurrent).get();
 	}

--- a/core/src/main/java/com/electronwill/nightconfig/core/AbstractConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/AbstractConfig.java
@@ -3,7 +3,6 @@ package com.electronwill.nightconfig.core;
 import com.electronwill.nightconfig.core.utils.TransformingSet;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/CheckedCommentedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/CheckedCommentedConfig.java
@@ -15,8 +15,7 @@ import java.util.Set;
  *
  * @author TheElectronWill
  */
-class CheckedCommentedConfig extends CommentedConfigWrapper<CommentedConfig>
-		implements CommentedConfig {
+class CheckedCommentedConfig extends CommentedConfigWrapper<CommentedConfig> {
 	/**
 	 * Creates a new CheckedConfig around a commented configuration.
 	 * <p>

--- a/core/src/main/java/com/electronwill/nightconfig/core/Config.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/Config.java
@@ -2,7 +2,6 @@ package com.electronwill.nightconfig.core;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
 import static com.electronwill.nightconfig.core.utils.StringUtils.split;

--- a/core/src/main/java/com/electronwill/nightconfig/core/InMemoryCommentedFormat.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/InMemoryCommentedFormat.java
@@ -58,7 +58,7 @@ public class InMemoryCommentedFormat implements ConfigFormat<CommentedConfig> {
 
 	@Override
 	public boolean supportsType(Class<?> type) {
-		return true;
+		return supportPredicate.test(type);
 	}
 
 	@Override

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/AbstractConvertedConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/AbstractConvertedConfig.java
@@ -14,8 +14,7 @@ import java.util.function.Predicate;
  * @author TheElectronWill
  */
 @SuppressWarnings("unchecked")
-abstract class AbstractConvertedConfig<C extends Config> extends ConfigWrapper<C>
-		implements Config {
+abstract class AbstractConvertedConfig<C extends Config> extends ConfigWrapper<C> {
 	final Function<Object, Object> readConversion, writeConversion;
 	final Predicate<Class<?>> supportPredicate;
 	final ConfigFormat<?> format;

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/AnnotationUtils.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/AnnotationUtils.java
@@ -50,7 +50,7 @@ final class AnnotationUtils {
 		Conversion conversion = field.getAnnotation(Conversion.class);
 		if (conversion != null) {
 			try {
-				Constructor<? extends Converter> constructor = conversion.value()
+				Constructor<? extends Converter<?,?>> constructor = conversion.value()
 																		 .getDeclaredConstructor();
 				if (!constructor.isAccessible()) {
 					constructor.setAccessible(true);

--- a/core/src/main/java/com/electronwill/nightconfig/core/conversion/ConversionTable.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/conversion/ConversionTable.java
@@ -14,8 +14,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
-
 /**
  * Contains conversions functions organized by value's type. A ConversionTable grows as necessary.
  *

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
@@ -9,10 +9,11 @@ import java.nio.file.Path;
  * @author TheElectronWill
  */
 final class AutoreloadFileConfig<C extends FileConfig> extends ConfigWrapper<C> implements FileConfig {
-	private final FileWatcher watcher = FileWatcher.defaultInstance();
+	private final FileWatcher watcher;
 
-	AutoreloadFileConfig(C config) {
+	AutoreloadFileConfig(C config, FileWatcher watcher) {
 		super(config);
+		this.watcher = watcher;
 		watcher.addWatch(config.getNioPath(), config::load);
 	}
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
@@ -3,7 +3,6 @@ package com.electronwill.nightconfig.core.file;
 import com.electronwill.nightconfig.core.utils.ConfigWrapper;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 
 /**
@@ -14,11 +13,7 @@ final class AutoreloadFileConfig<C extends FileConfig> extends ConfigWrapper<C> 
 
 	AutoreloadFileConfig(C config) {
 		super(config);
-		try {
-			watcher.addWatch(config.getFile(), config::load);
-		} catch (IOException e) {
-			throw new RuntimeException("Unable to create the autoreloaded config", e);
-		}
+		watcher.addWatch(config.getFile(), config::load);
 	}
 
 	@Override

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/AutoreloadFileConfig.java
@@ -13,7 +13,7 @@ final class AutoreloadFileConfig<C extends FileConfig> extends ConfigWrapper<C> 
 
 	AutoreloadFileConfig(C config) {
 		super(config);
-		watcher.addWatch(config.getFile(), config::load);
+		watcher.addWatch(config.getNioPath(), config::load);
 	}
 
 	@Override
@@ -38,7 +38,7 @@ final class AutoreloadFileConfig<C extends FileConfig> extends ConfigWrapper<C> 
 
 	@Override
 	public void close() {
-		watcher.removeWatch(config.getFile());
+		watcher.removeWatch(config.getNioPath());
 		config.close();
 	}
 }

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
@@ -1,13 +1,24 @@
 package com.electronwill.nightconfig.core.file;
 
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.*;
-import java.util.Iterator;
+import java.nio.file.FileSystem;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 /**
@@ -21,95 +32,124 @@ import java.util.function.Consumer;
  * @author TheElectronWill
  */
 public final class FileWatcher {
-	private static final long SLEEP_TIME_NANOS = 1000;
 	private static volatile FileWatcher DEFAULT_INSTANCE;
 
 	/**
 	 * Gets the default, global instance of FileWatcher.
+	 * If the previous global instance has been stopped, create and start a new instance.
 	 *
 	 * @return the default FileWatcher
 	 */
 	public static synchronized FileWatcher defaultInstance() {
-		if (DEFAULT_INSTANCE == null || !DEFAULT_INSTANCE.run) {// null or stopped FileWatcher
+		if (DEFAULT_INSTANCE == null || !DEFAULT_INSTANCE.running) {// null or stopped FileWatcher
 			DEFAULT_INSTANCE = new FileWatcher();
 		}
 		return DEFAULT_INSTANCE;
 	}
 
-	private final Map<Path, WatchedDir> watchedDirs = new ConcurrentHashMap<>();//dir -> watchService & infos
-	private final Map<Path, WatchedFile> watchedFiles = new ConcurrentHashMap<>();//file -> watchKey & handler
-	private final Thread thread = new WatcherThread();
+	public static class WatchingException extends RuntimeException {
+		public WatchingException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+		public WatchingException(Throwable cause) {
+			super(cause);
+		}
+
+		public WatchingException(String message) {
+			super(message);
+		}
+	}
+
+	private final ConcurrentMap<FileSystem, FSWatcher> watchers = new ConcurrentHashMap<>();
 	private final Consumer<Exception> exceptionHandler;
-	private volatile boolean run = true;
+	private volatile boolean running = true;
 
 	/**
-	 * Creates a new FileWatcher. The watcher is immediately functional, there is no need (and no
-	 * way, actually) to start it manually.
+	 * Creates a new FileWatcher with a default exception handler.
+	 * The default exception handler is simply:
+	 * <code>
+	 * (e) -> e.printStackTrace();
+	 * </code>
 	 */
 	public FileWatcher() {
 		this(Throwable::printStackTrace);
 	}
 
 	/**
-	 * Creates a new FileWatcher. The watcher is immediately functional, there is no need (and no
-	 * way, actually) to start it manually.
+	 * Creates a new FileWatcher.
 	 */
 	public FileWatcher(Consumer<Exception> exceptionHandler) {
 		this.exceptionHandler = exceptionHandler;
-		thread.start();
 	}
 
 	/**
 	 * Watches a file, if not already watched by this FileWatcher.
+	 * The file's parent directory must exist.
 	 *
 	 * @param file          the file to watch
 	 * @param changeHandler the handler to call when the file is modified
 	 */
-	public void addWatch(File file, Runnable changeHandler) throws IOException {
+	public void addWatch(File file, Runnable changeHandler) {
 		addWatch(file.toPath(), changeHandler);
 	}
 
 	/**
 	 * Watches a file, if not already watched by this FileWatcher.
+	 * The file's parent directory must exist.
 	 *
 	 * @param file          the file to watch
 	 * @param changeHandler the handler to call when the file is modified
 	 */
-	public void addWatch(Path file, Runnable changeHandler) throws IOException {
-		file = file.toAbsolutePath();// Ensures that the Path is absolute
-		Path dir = file.getParent();
-		WatchedDir watchedDir = watchedDirs.computeIfAbsent(dir, k -> new WatchedDir(dir));
-		WatchKey watchKey = dir.register(watchedDir.watchService,
-										 StandardWatchEventKinds.ENTRY_MODIFY);
-		watchedFiles.computeIfAbsent(file,
-									 k -> new WatchedFile(watchedDir, watchKey, changeHandler));
+	public void addWatch(Path file, Runnable changeHandler) {
+		addOrPutWatch(file, changeHandler, ControlMessageKind.ADD);
 	}
 
 	/**
 	 * Watches a file. If the file is already watched by this FileWatcher, its changeHandler is
 	 * replaced.
+	 * The file's parent directory must exist.
 	 *
 	 * @param file          the file to watch
 	 * @param changeHandler the handler to call when the file is modified
 	 */
-	public void setWatch(File file, Runnable changeHandler) throws IOException {
+	public void setWatch(File file, Runnable changeHandler) {
 		setWatch(file.toPath(), changeHandler);
 	}
 
 	/**
 	 * Watches a file. If the file is already watched by this FileWatcher, its changeHandler is
 	 * replaced.
+	 * The file's parent directory must exist.
 	 *
 	 * @param file          the file to watch
 	 * @param changeHandler the handler to call when the file is modified
 	 */
-	public void setWatch(Path file, Runnable changeHandler) throws IOException {
-		file = file.toAbsolutePath();// Ensures that the Path is absolute
-		WatchedFile watchedFile = watchedFiles.get(file);
-		if (watchedFile == null) {
-			addWatch(file, changeHandler);
-		} else {
-			watchedFile.changeHandler = changeHandler;
+	public void setWatch(Path file, Runnable changeHandler) {
+		addOrPutWatch(file, changeHandler, ControlMessageKind.PUT);
+	}
+
+	private void addOrPutWatch(Path file, Runnable changeHandler, ControlMessageKind kind) {
+		CanonicalPath canon = CanonicalPath.from(file);
+		FileSystem fs = canon.parentDirectory.getFileSystem();
+		try {
+			FSWatcher watcher = watchers.computeIfAbsent(fs, k -> {
+				// start a new watcher for this filesystem
+				try {
+					WatchService service = fs.newWatchService();
+					FSWatcher w = new FSWatcher(service);
+					Thread t = new Thread(w);
+					t.start();
+					t.setDaemon(true);
+					return w;
+				} catch (IOException ex) {
+					throw new WatchingException("Failed to start a new watcher thread for directory " + canon.parentDirectory, ex);
+				}
+			});
+			// tell the watcher thread to watch the file
+			watcher.send(new ControlMessage(kind, canon, changeHandler));
+		} catch (Exception ex) {
+			throw new WatchingException("Failed to watch path '" + file + "', canonical path '" + canon + "'", ex);
 		}
 	}
 
@@ -128,16 +168,11 @@ public final class FileWatcher {
 	 * @param file the file to stop watching
 	 */
 	public void removeWatch(Path file) {
-		file = file.toAbsolutePath();// Ensures that the Path is absolute
-		Path dir = file.getParent();
-		WatchedDir watchedDir = watchedDirs.get(dir);
-		int remainingChildCount = watchedDir.watchedFileCount.decrementAndGet();
-		if (remainingChildCount == 0) {
-			watchedDirs.remove(dir);
-		}
-		WatchedFile watchedFile = watchedFiles.remove(file);
-		if (watchedFile != null) {
-			watchedFile.watchKey.cancel();
+		CanonicalPath canon = CanonicalPath.from(file);
+		FileSystem fs = canon.parentDirectory.getFileSystem();
+		FSWatcher watcher = watchers.get(fs);
+		if (watcher != null) {
+			watcher.send(new ControlMessage(ControlMessageKind.REMOVE, canon, null));
 		}
 	}
 
@@ -145,94 +180,214 @@ public final class FileWatcher {
 	 * Stops this FileWatcher. The underlying ressources (ie the WatchServices) are closed, and
 	 * the file modification handlers won't be called anymore.
 	 */
-	public void stop() throws IOException {
-		run = false;
+	public void stop() {
+		running = false; // volatile write
 	}
 
-	private final class WatcherThread extends Thread {
-		{
-			setDaemon(true);
+	/** A directory watcher for one filesystem. */
+	private final class FSWatcher implements Runnable {
+		private final WatchService watchService;
+		private final Map<Path, WatchedDirectory> watchedDirectories = new HashMap<>();
+		private final ConcurrentLinkedQueue<ControlMessage> controlMessages = new ConcurrentLinkedQueue<>();
+
+		FSWatcher(WatchService watchService) {
+			this.watchService = watchService;
+		}
+
+		void send(ControlMessage msg) {
+			controlMessages.add(msg);
+		}
+
+		private WatchedDirectory watchDirectory(Path dir) {
+			return watchedDirectories.computeIfAbsent(dir, k -> {
+				// the file's parent directory isn't monitored yet, register it
+				WatchKey key;
+				try {
+					key = dir.register(watchService, ENTRY_MODIFY, ENTRY_CREATE);
+					return new WatchedDirectory(key, new HashMap<>(8));
+				} catch (IOException e) {
+					exceptionHandler.accept(e);
+					return null;
+				}
+			});
+		}
+
+		private void close() throws IOException {
+			watchService.close();
+			watchedDirectories.clear();
 		}
 
 		@Override
 		public void run() {
-			while (run) {
-				boolean allNull = true;
-				dirsIter:
-				for (Iterator<WatchedDir> it = watchedDirs.values().iterator(); it.hasNext() && run; ) {
-					WatchedDir watchedDir = it.next();
-					WatchKey key = watchedDir.watchService.poll();
-					if (key == null) {
-						continue;
+			while (running) {
+				// handle control messages coming from other threads (modification of the watch list)
+				ControlMessage msg;
+				while ((msg = controlMessages.poll()) != null) {
+					Path dir = msg.parentDirectory;
+					Path fileName = msg.fileName;
+					switch (msg.kind) {
+						case ADD: {
+							// Combine the handlers if there's already one, otherwise set it
+							WatchedDirectory w = watchDirectory(dir);
+							if (w != null) {
+								Runnable existingHandler = w.fileChangeHandlers.get(fileName);
+								Runnable msgHandler = msg.handler;
+								Runnable newHandler;
+								if (existingHandler != null) {
+									// combine the handlers
+									newHandler = () -> {
+										existingHandler.run();
+										msgHandler.run();
+									};
+								} else {
+									newHandler = msgHandler;
+								}
+								w.fileChangeHandlers.put(fileName, newHandler);
+							}
+							break;
+						}
+						case PUT: {
+							// Set the handler, replacing any existing handler
+							WatchedDirectory w = watchDirectory(dir);
+							if (w != null) {
+								w.fileChangeHandlers.put(fileName, msg.handler);
+							}
+							break;
+						}
+						case REMOVE: {
+							// Stop watching a file
+							WatchedDirectory w = watchedDirectories.get(dir);
+							if (w != null) {
+								w.fileChangeHandlers.remove(fileName);
+								if (w.fileChangeHandlers.isEmpty()) {
+									// no more file to watch in this directory
+									w.key.cancel();
+									// this will be done in the event loop below: watchedDirectories.remove(dir);
+								}
+							}
+							break;
+						}
+						default: {
+							break;
+						}
 					}
-					allNull = false;
-					for (WatchEvent<?> event : key.pollEvents()) {
-						if (!run) {
-							break dirsIter;
-						}
-						if (event.kind() != StandardWatchEventKinds.ENTRY_MODIFY || event.count() > 1) {
-							continue;
-						}
-						Path childPath = ((WatchEvent<Path>)event).context();
-						Path filePath = watchedDir.dir.resolve(childPath);
-						WatchedFile watchedFile = watchedFiles.get(filePath);
-						if (watchedFile != null) {
-							try {
-								watchedFile.changeHandler.run();
-							} catch (Exception e) {
-								exceptionHandler.accept(e);
+				}
+
+				// poll the events from the filesystem (monitoring of the files)
+				WatchKey key = null;
+				try {
+					key = watchService.poll(100, TimeUnit.MILLISECONDS);
+				} catch (InterruptedException e) {
+					// we can proceed
+				}
+
+				if (key == null) {
+					// no key available after the given delay, or interrupted
+					continue;
+				} else {
+					Path dir = (Path) key.watchable();
+					WatchedDirectory w = watchedDirectories.get(dir);
+					for (WatchEvent<?> evt : key.pollEvents()) {
+						WatchEvent.Kind<?> kind = evt.kind();
+						if (kind == StandardWatchEventKinds.OVERFLOW) {
+							// The probability of this happening is very low, and what to do is not obvious, especially from the pov of our library.
+							// We could add a specific handler so that we can optionnaly notify the user and reload all files if they want to.
+							exceptionHandler.accept(new WatchingException("Got event OVERFLOW"));
+						} else {
+							Path file = (Path)evt.context();
+							Runnable changeHandler = w.fileChangeHandlers.get(file);
+							if (changeHandler != null) {
+								// The handler is null if the file that has changed is not in the list of monitored files
+								// (there exist a sibling file in the same directory that we want to monitor).
+								// A WatchService monitors directories, not files, that's why we need to do a check here.
+								try {
+									changeHandler.run();
+								} catch (Exception ex) {
+									exceptionHandler.accept(ex);
+									// TODO: change the API to pass more information to the exception handler and the change handler
+								}
 							}
 						}
+						if (!running) {
+							break; // early stop
+						}
 					}
-					key.reset();
-				}
-				if (allNull) {
-					LockSupport.parkNanos(SLEEP_TIME_NANOS);
-				}
-			}
-			// Closes the WatchServices
-			for (WatchedDir watchedDir : watchedDirs.values()) {
-				try {
-					watchedDir.watchService.close();
-				} catch (IOException e) {
-					exceptionHandler.accept(e);
+					boolean valid = key.reset();
+					if (!valid) {
+						// key cancelled explicitely, or WatchService closed, or directory no longer accessible
+						// To account for the latter case (dir no longer accessible), we need to remove the dir from our map.
+						watchedDirectories.remove(dir);
+						break;
+					}
 				}
 			}
-			// Clears the maps
-			watchedDirs.clear();
-			watchedFiles.clear();
-		}
-	}
-
-	/**
-	 * Informations about a watched directory, ie a directory that contains watched files.
-	 */
-	private static final class WatchedDir {
-		final Path dir;
-		final WatchService watchService;
-		final AtomicInteger watchedFileCount = new AtomicInteger();
-
-		private WatchedDir(Path dir) {
-			this.dir = dir;
 			try {
-				this.watchService = dir.getFileSystem().newWatchService();
+				close();
 			} catch (IOException e) {
-				throw new RuntimeException(e);
+				exceptionHandler.accept(e);
 			}
 		}
 	}
 
-	/**
-	 * Informations about a watched file, with an associated handler.
-	 */
-	private static final class WatchedFile {
-		final WatchKey watchKey;
-		volatile Runnable changeHandler;
+	private static final class WatchedDirectory {
+		final WatchKey key;
+		final Map<Path, Runnable> fileChangeHandlers;
 
-		private WatchedFile(WatchedDir watchedDir, WatchKey watchKey, Runnable changeHandler) {
-			this.watchKey = watchKey;
-			this.changeHandler = changeHandler;
-			watchedDir.watchedFileCount.getAndIncrement();
+		WatchedDirectory(WatchKey key, Map<Path, Runnable> fileChangeHandlers) {
+			this.key = Objects.requireNonNull(key);
+			this.fileChangeHandlers = Objects.requireNonNull(fileChangeHandlers);
 		}
 	}
+
+	private static final class ControlMessage {
+		final ControlMessageKind kind;
+		final Path parentDirectory, fileName;
+		final Runnable handler; // null for some kinds of messages
+
+		ControlMessage(ControlMessageKind kind, CanonicalPath path, Runnable handler) {
+			this.parentDirectory = path.parentDirectory;
+			this.fileName = path.fileName;
+			this.kind = kind;
+			this.handler = handler;
+		}
+	}
+
+	private static class CanonicalPath {
+		public final Path parentDirectory, fileName;
+
+		private CanonicalPath(Path parentDirectory, Path fileName) {
+			this.parentDirectory = parentDirectory;
+			this.fileName = fileName;
+		}
+
+		public static CanonicalPath from(Path fullFilePath) {
+			try {
+			// To avoid duplicate entries in the map of dirs, make the path absolute and resolve links and special names like ".."
+			// toRealPath() only works if the file exists, so we call `toRealPath` on its parent if it doesn't
+			Path dir, fileName;
+			try {
+				Path realFile = fullFilePath.toRealPath();
+				dir = realFile.getParent();
+				fileName = realFile.getFileName();
+			} catch (NoSuchFileException e) {
+				dir = fullFilePath.getParent().toRealPath();
+				fileName = fullFilePath.getFileName();
+			}
+			return new CanonicalPath(dir, fileName);
+			} catch (IOException ex) {
+				throw new WatchingException("Failed to determine the canonical path of: " + fullFilePath, ex);
+			}
+		}
+
+		@Override
+		public String toString() {
+			return parentDirectory + "/" + fileName;
+		}
+
+	}
+
+	private static enum ControlMessageKind {
+		PUT, ADD, REMOVE
+	}
+
 }

--- a/core/src/test/java/com/electronwill/nightconfig/core/file/FileWatcherTest.java
+++ b/core/src/test/java/com/electronwill/nightconfig/core/file/FileWatcherTest.java
@@ -1,0 +1,218 @@
+package com.electronwill.nightconfig.core.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.electronwill.nightconfig.core.file.FileWatcher.DebouncedRunnable;
+
+public class FileWatcherTest {
+
+	@TempDir
+	static Path tmp;
+
+	static final Consumer<Throwable> onWatcherException = e -> {
+		throw new RuntimeException(e); // fail the test
+	};
+
+	@Test
+	public void singleFile() throws Exception {
+		// no debouncing, no waiting on underlying filesystem watcher (handles new messages immediately)
+		FileWatcher watcher = new FileWatcher(Duration.ZERO, Duration.ZERO, onWatcherException);
+
+		// ---- watch new file
+		Path file = tmp.resolve("fileNotifications.txt"); // does not exist yet
+		AtomicReference<CountDownLatch> ref = new AtomicReference<>(new CountDownLatch(1));
+		watcher.addWatch(file, () -> ref.get().countDown());
+		// wait a little bit to ensure that the wacher is all set up
+		// (there is a background thread that needs to handle the commands sent by
+		// addWatch)
+		Thread.sleep(10);
+
+		Files.createFile(file); // creates the file (1st notif)
+		assertTrue(ref.get().await(100, TimeUnit.MILLISECONDS), "creation not detected");
+
+		// reset count and write
+		ref.set(new CountDownLatch(1));
+		Files.write(file, Arrays.asList("something something")); // writes (2nd notif)
+		assertTrue(ref.get().await(100, TimeUnit.MILLISECONDS), "write not detected");
+
+		// reset count and write again
+		ref.set(new CountDownLatch(1));
+		Files.write(file, Arrays.asList("something else")); // writes (3rd notif)
+		assertTrue(ref.get().await(100, TimeUnit.MILLISECONDS), "write not detected");
+
+		ref.set(null); // if the handler is called again, which it should not, fail the test
+
+		// ---- watch existing file
+		file = tmp.resolve("fileNotifications-2.txt");
+		ref.set(new CountDownLatch(1));
+		Files.createFile(file);
+		watcher.addWatch(file, () -> ref.get().countDown());
+		Thread.sleep(10);
+
+		Files.write(file, Arrays.asList("test2"));
+		assertTrue(ref.get().await(100, TimeUnit.MILLISECONDS));
+
+		// ---- change the watcher
+		CountDownLatch newLatch = new CountDownLatch(1);
+		watcher.setWatch(file, () -> newLatch.countDown());
+		Thread.sleep(10);
+		Files.write(file, Arrays.asList(":)"));
+		assertTrue(ref.get().await(100, TimeUnit.MILLISECONDS));
+
+		// ---- stop watching
+		ref.set(null);
+		watcher.removeWatch(file);
+		Thread.sleep(10);
+		Files.write(file, Arrays.asList("..."));
+		Thread.sleep(50);
+
+		// ---- shutdown the watcher
+		watcher.stop();
+	}
+
+	/** Watches multiple files in multiple directories. */
+	@Test
+	public void multipleFiles() throws Exception {
+		int nDirs = 10;
+		int nFiles = 10;
+		FileWatcher watcher = new FileWatcher(Duration.ZERO, Duration.ZERO, onWatcherException);
+		CountDownLatch latch = new CountDownLatch(nDirs*nFiles);
+		// watch many files
+		for (int i = 0; i < nDirs; i++) {
+			Path dir = tmp.resolve("sub-" + i);
+			Files.createDirectory(dir);
+			for (int j = 0; j < nFiles; j++) {
+				Path file = dir.resolve("multipleFilesNotifications-" + j);
+				watcher.addWatch(file, latch::countDown);
+			}
+		}
+		// generate an event on all the files
+		for (int i = 0; i < nDirs; i++) {
+			for (int j = 0; j < nFiles; j++) {
+				Path dir = tmp.resolve("sub-" + i);
+				Path file = dir.resolve("multipleFilesNotifications-" + j);
+				Files.createFile(file);
+			}
+		}
+		// check that all the handlers have been called
+		assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
+
+		// stop watching
+		watcher.stop();
+	}
+
+	@Test
+	public void multipleThreads() throws Exception {
+		int n = 100;
+		Path tmpFile = tmp.resolve("multipleThreads.txt");
+		FileWatcher watcher = new FileWatcher(Duration.ofMillis(100), Duration.ZERO, onWatcherException);
+		CountDownLatch latch = new CountDownLatch(n);
+		List<Thread> threads = new ArrayList<>(n);
+		// watch the file, from different threads
+		for (int i = 0; i < n; i++) {
+			Thread adder = new Thread(() -> {
+				watcher.addWatch(tmpFile, latch::countDown);
+			});
+			threads.add(adder);
+			adder.start();
+		}
+		// wait for the watchers to activate (should be quick)
+		for (Thread adder : threads) {
+			adder.join(50);
+		}
+		// write to the file (generates an event)
+		Files.write(tmpFile, Arrays.asList("test"));
+
+		// check that all the handlers have been called
+		latch.await(200, TimeUnit.MILLISECONDS);
+
+		// stop watching
+		watcher.stop();
+	}
+
+	@Test
+	public void rejectWhenStopped() throws Exception {
+		FileWatcher watcher = new FileWatcher();
+		watcher.stop();
+		assertThrows(IllegalStateException.class, () -> {
+			watcher.addWatch(tmp.resolve("whatever"), () -> {
+				throw new RuntimeException("I should not be called!");
+			});
+		});
+	}
+
+	@Test
+	public void debouncing() throws Exception {
+		int n = 100;
+		Path file = tmp.resolve("debouncing");
+		Duration debounceTime = Duration.ofMillis(100);
+		Duration debounceAndTolerance = debounceTime.plusMillis(10); // tolerate some delay on top of the debounce time
+		FileWatcher watcher = new FileWatcher(debounceTime, onWatcherException);
+
+		// watch the file
+		AtomicInteger callCounter = new AtomicInteger(0);
+		watcher.addWatch(file, () -> callCounter.getAndIncrement());
+
+		// generate plenty of events, they should be debounced to only one
+		Files.createFile(file);
+		for (int i = 0; i < n; i++) {
+			Files.write(file, Arrays.asList("a" + i));
+		}
+		assertEquals(0, callCounter.get());
+		Thread.sleep(debounceAndTolerance.toMillis());
+		assertEquals(1, callCounter.get());
+
+		// modify the file again
+		for (int j = 0; j < n; j++) {
+			Files.write(file, Arrays.asList("b" + j));
+		}
+		Thread.sleep(debounceAndTolerance.toMillis());
+		assertEquals(2, callCounter.get());
+
+		watcher.stop();
+	}
+
+	@Test
+	public void debouncingInternals() throws Exception {
+		ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+		Duration debounceDuration = Duration.ofMillis(10);
+		Duration debounceAndTolerance = debounceDuration.plusMillis(5);
+
+		AtomicInteger callCounter = new AtomicInteger(0);
+		DebouncedRunnable r = new DebouncedRunnable(callCounter::getAndIncrement, debounceDuration);
+
+		// call the DebouncedRunnable once and check that it's debounced
+		r.run(executor);
+		assertEquals(0, callCounter.get());
+		Thread.sleep(debounceAndTolerance.toMillis());
+		assertEquals(1, callCounter.get());
+
+		// call it many times and check
+		int n = 100;
+		for (int i = 0; i < n; i++) {
+			r.run(executor);
+		}
+		assertEquals(1, callCounter.get());
+		Thread.sleep(debounceAndTolerance.toMillis());
+		assertEquals(2, callCounter.get());
+	}
+}

--- a/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
+++ b/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
@@ -1,6 +1,5 @@
 package com.electronwill.nightconfig.core.io;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/examples/src/main/java/AutoreloadExample.java
+++ b/examples/src/main/java/AutoreloadExample.java
@@ -1,4 +1,5 @@
 import com.electronwill.nightconfig.core.file.FileConfig;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -8,17 +9,31 @@ import java.io.IOException;
  */
 public class AutoreloadExample {
 	public static void main(String[] args) throws IOException, InterruptedException {
-		// Creates an autoreloaded config:
+		// Create an autoreloaded config
 		File configFile = new File("autoreload.json");
 		FileConfig config = FileConfig.builder(configFile).autoreload().build();
 		System.out.println("Config: " + config.valueMap());
 
-		// Modifies the file:
+		// Wait a bit for the file monitoring to start
+		Thread.sleep(250);
+
+		// Modify the file
 		try (FileWriter writer = new FileWriter(configFile)) {
 			writer.write("{ \"value\": 123 }");
 		}
-		Thread.sleep(1000);// The modifications take some (short) time to be detected
-		System.out.println("Config: " + config);// You should see "Config: {value=123}"
+		Thread.sleep(100); // The modifications take some time to be detected (usually < 1 second)
+		System.out.println("Config: " + config.valueMap());// Config: {value=123}
+
+		// Modify again
+		// The reloading of configurations is throttled: a minimum delay is ensured between two reloading.
+		try (FileWriter writer = new FileWriter(configFile)) {
+			writer.write("{ \"value\": -1, \"it_works\": \"yes!\" }");
+		}
+		// throttling, the config is not reloaded immediately
+		System.out.println("Config: " + config.valueMap());// Config: {value=123}
+
+		Thread.sleep(500); // wait until the throttling delay expires, and then look at the config again
+		System.out.println("Config: " + config.valueMap());// Config: {it_works=yes!, value=-1}
 
 		/* Don't forget to close the config! In that case the program terminates so it's not a
 		big deal, but otherwise it's important to close the FileConfig in order to release the

--- a/examples/src/main/java/AutosaveExample.java
+++ b/examples/src/main/java/AutosaveExample.java
@@ -1,6 +1,5 @@
 import com.electronwill.nightconfig.core.file.FileConfig;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 

--- a/examples/src/main/java/FileConfigDefaultResource.java
+++ b/examples/src/main/java/FileConfigDefaultResource.java
@@ -1,0 +1,18 @@
+import java.io.File;
+
+import com.electronwill.nightconfig.core.file.FileConfig;
+
+public class FileConfigDefaultResource {
+	public static void main(String[] args) {
+		File localFile = new File("local-file.json");
+		localFile.delete();
+
+		FileConfig conf = FileConfig.builder(localFile).defaultResource("some-resource.json").build();
+		conf.load();
+
+		System.out.println(conf);
+
+		conf.set("value", "added to the local file");
+		conf.save();
+	}
+}

--- a/examples/src/main/resources/some-resource.json
+++ b/examples/src/main/resources/some-resource.json
@@ -1,0 +1,3 @@
+{
+	"default-key": "copied from the default resource"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectDescription=Powerful, easy-to-use and multi-language configuration library for the JVM
 projectGroup=com.electronwill.night-config
-projectVersion=3.6.7
+projectVersion=3.7.0
 
 projectUrl=https://github.com/TheElectronWill/Night-Config
 projectWebScm='https://github.com/TheElectronWill/Night-Config/tree/master'
@@ -13,7 +13,6 @@ publishReleaseUrl=https://oss.sonatype.org/service/local/staging/deploy/maven2
 ossrhUser=dummyUser
 ossrhPassword=dummyPassword
 
-javaVersion=1.8
-junitVersion=5.9.2
+junitVersion=5.10.1
 snakeYamlVersion=1.33
-typesafeConfigVersion=1.4.2
+typesafeConfigVersion=1.4.3

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlFormatTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlFormatTest.java
@@ -1,12 +1,12 @@
 package com.electronwill.nightconfig.toml;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 class TomlFormatTest {
 
 	@Test
 	public void noNulls() {
-		Assertions.assertFalse(TomlFormat.instance().supportsType(null));
+		assertFalse(TomlFormat.instance().supportsType(null));
 	}
 }

--- a/yaml/src/test/java/yaml/YamlTest.java
+++ b/yaml/src/test/java/yaml/YamlTest.java
@@ -36,6 +36,7 @@ public class YamlTest {
 		config.set("enum", BasicTestEnum.A); // complex enums doesn't appear to work with SnakeYAML
 		config.set("list", Arrays.asList(10, 12));
 		config.set("objectList", Arrays.asList(config1, config2));
+		config.set(Arrays.asList("not.a.subconfig"), "works");
 
 		System.out.println("Config: " + config);
 		System.out.println("classOf[sub] = " + config.get("sub").getClass());
@@ -44,7 +45,7 @@ public class YamlTest {
 		YamlFormat yamlFormat = YamlFormat.defaultInstance();
 		yamlFormat.createWriter().write(config, file, WritingMode.REPLACE);
 
-		Config parsed = yamlFormat.createConcurrentConfig();
+		Config parsed = yamlFormat.createConfig();
 		yamlFormat.createParser().parse(file, parsed, ParsingMode.REPLACE, THROW_ERROR);
 		System.out.println("\nParsed: " + parsed);
 		System.out.println("classOf[sub] = " + parsed.get("sub").getClass());
@@ -55,7 +56,7 @@ public class YamlTest {
 		assertEquals(BasicTestEnum.A, parsed.getEnum("enum", BasicTestEnum.class));
 		assertEquals(12, parsed.<List<Integer>>get("list").get(1));
 		assertEquals(Boolean.TRUE, parsed.<List<UnmodifiableConfig>>get("objectList").get(1).get("baz"));
-
-		Assertions.assertEquals(config, parsed, "Error: written != parsed");
+		assertEquals("works", parsed.<String>get(Arrays.asList("not.a.subconfig")));
+		Assertions.assertEquals(config, parsed, "written != parsed");
 	}
 }

--- a/yaml/src/test/java/yaml/YamlTest.java
+++ b/yaml/src/test/java/yaml/YamlTest.java
@@ -57,6 +57,6 @@ public class YamlTest {
 		assertEquals(12, parsed.<List<Integer>>get("list").get(1));
 		assertEquals(Boolean.TRUE, parsed.<List<UnmodifiableConfig>>get("objectList").get(1).get("baz"));
 		assertEquals("works", parsed.<String>get(Arrays.asList("not.a.subconfig")));
-		Assertions.assertEquals(config, parsed, "written != parsed");
+		assertEquals(config, parsed, "written != parsed");
 	}
 }

--- a/yaml/test.yml
+++ b/yaml/test.yml
@@ -1,6 +1,7 @@
 sub: {'null': null, nullObject: null}
 'null': null
 string: this is a string
+not.a.subconfig: works
 nullObject: null
 list: [10, 12]
 enum: !!com.electronwill.nightconfig.core.BasicTestEnum 'A'


### PR DESCRIPTION
- Use only one WatchService per filesystem
- Add a configurable throttling delay to avoid reloading configuration too often (todo: make it a `debounce` instead)
- Use `WatchService#poll(timeout, unit)` instead of `poll()` to wait for events instead of busy looping
- and more improvements :)