### PR TITLE
Fix squeezed Toml Files

### DIFF
--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -95,7 +95,8 @@ final class TableWriter {
 			// Writes the table's content
 			writeNormal(entry.<UnmodifiableConfig>getValue(), configPath, output, writer);
 			configPath.remove(configPath.size() - 1);// path level --
-			if (!configPath.isEmpty()) writer.writeNewline(output); // separates Tables
+			System.out.println("Config Path Size: " + configPath.size());
+			writer.writeNewline(output); // separates Tables
 		}
 
 		// Writes the arrays of tables:
@@ -112,7 +113,7 @@ final class TableWriter {
 				writeNormal(table, configPath, output, writer);
 			}
 			configPath.remove(configPath.size() - 1);// path level --
-			if (!configPath.isEmpty()) writer.writeNewline(output); // separates each written ArrayList Table
+			writer.writeNewline(output); // separates each written ArrayList Table
 		}
 		writer.decreaseIndentLevel();// Indent--
 	}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -95,7 +95,7 @@ final class TableWriter {
 			// Writes the table's content
 			writeNormal(entry.<UnmodifiableConfig>getValue(), configPath, output, writer);
 			configPath.remove(configPath.size() - 1);// path level --
-			writer.writeNewline(output); // separates Tables without effecting ArrayList
+			if (!configPath.isEmpty()) writer.writeNewline(output); // separates Tables
 		}
 
 		// Writes the arrays of tables:
@@ -112,7 +112,7 @@ final class TableWriter {
 				writeNormal(table, configPath, output, writer);
 			}
 			configPath.remove(configPath.size() - 1);// path level --
-			writer.writeNewline(output); // separates each written ArrayList Table
+			if (!configPath.isEmpty()) writer.writeNewline(output); // separates each written ArrayList Table
 		}
 		writer.decreaseIndentLevel();// Indent--
 	}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -95,7 +95,6 @@ final class TableWriter {
 			// Writes the table's content
 			writeNormal(entry.<UnmodifiableConfig>getValue(), configPath, output, writer);
 			configPath.remove(configPath.size() - 1);// path level --
-			System.out.println("Config Path Size: " + configPath.size());
 			writer.writeNewline(output); // separates Tables
 		}
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -112,6 +112,7 @@ final class TableWriter {
 				writeNormal(table, configPath, output, writer);
 			}
 			configPath.remove(configPath.size() - 1);// path level --
+			writer.writeNewline(output); // separates each written ArrayList Table
 		}
 		writer.decreaseIndentLevel();// Indent--
 	}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java
@@ -95,6 +95,7 @@ final class TableWriter {
 			// Writes the table's content
 			writeNormal(entry.<UnmodifiableConfig>getValue(), configPath, output, writer);
 			configPath.remove(configPath.size() - 1);// path level --
+			writer.writeNewline(output); // separates Tables without effecting ArrayList
 		}
 
 		// Writes the arrays of tables:

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.StringWriter;
-import java.sql.Array;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,7 +66,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		assertLinesMatch(Arrays.asList("[table]", "\tkey = \"value\"", "", ""), StringUtils.splitLines(written));
+		assertLinesMatch(Arrays.asList("[table]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
 	}
 
 	@Test
@@ -83,7 +82,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		assertLinesMatch(Arrays.asList("[[aot]]", "\tkey = \"value\"", "", ""), StringUtils.splitLines(written));
+		assertLinesMatch(Arrays.asList("[[aot]]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
 	}
 
 	@Test
@@ -108,7 +107,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		assertLinesMatch(Arrays.asList("simple = 123", "", "[table]", "\tkey = \"value\"", "", ""),
+		assertLinesMatch(Arrays.asList("simple = 123", "", "[table]", "\tkey = \"value\"", ""),
 				StringUtils.splitLines(written));
 	}
 
@@ -124,7 +123,7 @@ public class TomlWriterTest {
 		TomlWriter writer = new TomlWriter();
 		String written = writer.writeToString(config);
 		System.out.println(written);
-		assertLinesMatch(Arrays.asList("[first]", "\tkey = \"value\"", "", "[second]", "\tkey = \"value\"", "", ""),
+		assertLinesMatch(Arrays.asList("[first]", "\tkey = \"value\"", "", "[second]", "\tkey = \"value\"", ""),
 			StringUtils.splitLines(written));
 	}
 
@@ -146,7 +145,7 @@ public class TomlWriterTest {
 		System.out.println(written);
 
 		assertLinesMatch(Arrays.asList("[[firstArray]]", "\tkey = \"value\"", "[[firstArray]]", "\tkey = \"value\"", "",
-			"[[secondArray]]", "\tkey = \"value\"", "[[secondArray]]", "\tkey = \"value\"", "", ""),
+			"[[secondArray]]", "\tkey = \"value\"", "[[secondArray]]", "\tkey = \"value\"", ""),
 			StringUtils.splitLines(written));
 	}
 

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.StringWriter;
+import java.sql.Array;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +44,7 @@ public class TomlWriterTest {
 		config.set("bool_array", Arrays.asList(true, false, true, false));
 		config.set("config", subConfig);
 		config.set("table_array", tableArray);
+		config.set("table_array2", tableArray);
 		config.set("enum", TestEnum.A);
 
 		StringWriter stringWriter = new StringWriter();
@@ -56,7 +58,7 @@ public class TomlWriterTest {
 	}
 
 	@Test
-	public void correctNewlinesSub() {
+	public void correctNewlinesSub() { // Test fails, because of additional empty line at the end
 		Config conf = TomlFormat.instance().createConfig();
 		Config sub = conf.createSubConfig();
 		conf.set("table", sub);
@@ -65,11 +67,12 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
+		// Fixable by adding "" at the end, because it only appears at the end of the file
 		assertLinesMatch(Arrays.asList("[table]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
 	}
 
 	@Test
-	public void correctNewlinesArrayOfTables() {
+	public void correctNewlinesArrayOfTables() {  // Test fails, because of additional empty line at the end
 		Config conf = TomlFormat.instance().createConfig();
 
 		Config sub = conf.createSubConfig();
@@ -81,6 +84,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
+		// Fixable by adding "" at the end, because it only appears at the end of the file
 		assertLinesMatch(Arrays.asList("[[aot]]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
 	}
 
@@ -96,7 +100,7 @@ public class TomlWriterTest {
 	}
 
 	@Test
-	public void correctNewlinesMixed() {
+	public void correctNewlinesMixed() {  // Test fails, because of additional empty line at the end
 		Config conf = TomlFormat.instance().createConfig();
 		Config sub = conf.createSubConfig();
 		conf.set("simple", 123);
@@ -106,9 +110,28 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
+		// Fixable by adding "" at the end, because it only appears at the end of the file
 		assertLinesMatch(Arrays.asList("simple = 123", "", "[table]", "\tkey = \"value\"", ""),
 				StringUtils.splitLines(written));
 	}
+
+	@Test
+	public void correctTableSeparation() {
+		Config conf = TomlFormat.instance().createConfig();
+		Config sub = conf.createSubConfig();
+
+		conf.set("first", sub);
+		conf.set("second", sub);
+		sub.set("key", "value");
+
+		TomlWriter writer = new TomlWriter();
+		String written = writer.writeToString(conf);
+		System.out.println(written);
+		assertLinesMatch(Arrays.asList("[first]", "\tkey = \"value\"", "", "[second]", "\tkey = \"value\"", "", ""),
+			StringUtils.splitLines(written));
+	}
+
+
 
 	@Test
 	public void noNulls() {

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -58,7 +58,7 @@ public class TomlWriterTest {
 	}
 
 	@Test
-	public void correctNewlinesSub() { // Test fails, because of additional empty line at the end
+	public void correctNewlinesSub() {
 		Config conf = TomlFormat.instance().createConfig();
 		Config sub = conf.createSubConfig();
 		conf.set("table", sub);
@@ -67,12 +67,11 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		// Fixable by adding "" at the end, because it only appears at the end of the file
-		assertLinesMatch(Arrays.asList("[table]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
+		assertLinesMatch(Arrays.asList("[table]", "\tkey = \"value\"", "", ""), StringUtils.splitLines(written));
 	}
 
 	@Test
-	public void correctNewlinesArrayOfTables() {  // Test fails, because of additional empty line at the end
+	public void correctNewlinesArrayOfTables() {
 		Config conf = TomlFormat.instance().createConfig();
 
 		Config sub = conf.createSubConfig();
@@ -84,8 +83,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		// Fixable by adding "" at the end, because it only appears at the end of the file
-		assertLinesMatch(Arrays.asList("[[aot]]", "\tkey = \"value\"", ""), StringUtils.splitLines(written));
+		assertLinesMatch(Arrays.asList("[[aot]]", "\tkey = \"value\"", "", ""), StringUtils.splitLines(written));
 	}
 
 	@Test
@@ -100,7 +98,7 @@ public class TomlWriterTest {
 	}
 
 	@Test
-	public void correctNewlinesMixed() {  // Test fails, because of additional empty line at the end
+	public void correctNewlinesMixed() {
 		Config conf = TomlFormat.instance().createConfig();
 		Config sub = conf.createSubConfig();
 		conf.set("simple", 123);
@@ -110,8 +108,7 @@ public class TomlWriterTest {
 		TomlWriter tWriter = new TomlWriter();
 		String written = tWriter.writeToString(conf);
 		System.out.println(written);
-		// Fixable by adding "" at the end, because it only appears at the end of the file
-		assertLinesMatch(Arrays.asList("simple = 123", "", "[table]", "\tkey = \"value\"", ""),
+		assertLinesMatch(Arrays.asList("simple = 123", "", "[table]", "\tkey = \"value\"", "", ""),
 				StringUtils.splitLines(written));
 	}
 

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -117,21 +117,41 @@ public class TomlWriterTest {
 
 	@Test
 	public void correctTableSeparation() {
-		Config conf = TomlFormat.instance().createConfig();
-		Config sub = conf.createSubConfig();
+		Config config = TomlFormat.instance().createConfig();
+		Config subConfig = config.createSubConfig();
 
-		conf.set("first", sub);
-		conf.set("second", sub);
-		sub.set("key", "value");
+		config.set("first", subConfig);
+		config.set("second", subConfig);
+		subConfig.set("key", "value");
 
 		TomlWriter writer = new TomlWriter();
-		String written = writer.writeToString(conf);
+		String written = writer.writeToString(config);
 		System.out.println(written);
 		assertLinesMatch(Arrays.asList("[first]", "\tkey = \"value\"", "", "[second]", "\tkey = \"value\"", "", ""),
 			StringUtils.splitLines(written));
 	}
 
+	@Test
+	public void correctTableArraySeparation() {
+		Config subConfig = TomlFormat.instance().createConfig();
+		subConfig.set("key", "value");
 
+		List<Config> tableArray = new ArrayList<>();
+		tableArray.add(subConfig);
+		tableArray.add(subConfig);
+
+		Config config = TomlFormat.instance().createConfig();
+		config.set("firstArray", tableArray);
+		config.set("secondArray", tableArray);
+
+		TomlWriter writer = new TomlWriter();
+		String written = writer.writeToString(config);
+		System.out.println(written);
+
+		assertLinesMatch(Arrays.asList("[[firstArray]]", "\tkey = \"value\"", "[[firstArray]]", "\tkey = \"value\"", "",
+			"[[secondArray]]", "\tkey = \"value\"", "[[secondArray]]", "\tkey = \"value\"", "", ""),
+			StringUtils.splitLines(written));
+	}
 
 	@Test
 	public void noNulls() {


### PR DESCRIPTION
As described in discussion #153, ​​the TableEntries were squeezed together by the new [check](https://github.com/TheElectronWill/night-config/blob/master/toml/src/main/java/com/electronwill/nightconfig/toml/TableWriter.java#L79C1-L83C4) in the TableWriter.

The check separates the TablesEntries from the normal/simple written values inside the Toml File.

This simple Solution separates the TableEntries and TableArrayEntries from each other without effecting the Entry or List by itself.
Means the ArrayList gets further squeezed together but when a new ArrayList is written a blank line is written in between.