### PR TITLE
Align List ending when in a "group"

### DIFF
--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayWriter.java
@@ -44,6 +44,7 @@ final class ArrayWriter {
 			writer.decreaseIndentLevel();
 			writer.writeNewline(output);
 		}
+		writer.writeIndent(output);
 		output.write(']');
 	}
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayWriter.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayWriter.java
@@ -43,8 +43,8 @@ final class ArrayWriter {
 		if (indent) {
 			writer.decreaseIndentLevel();
 			writer.writeNewline(output);
+			writer.writeIndent(output);
 		}
-		writer.writeIndent(output);
 		output.write(']');
 	}
 

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -40,7 +40,7 @@ public class TomlWriterTest {
 			"first line\n" +
 			"second line\n" +
 			"\tthird line (indented)\n" +
-			"fourth line!\"\"\"\n" + 
+			"fourth line!\"\"\"\n" +
 			"";
 		assertEquals(expected, result);
 
@@ -261,6 +261,27 @@ public class TomlWriterTest {
 				"a = 1",
 				"b = 2",
 				""), writerWithoutIndentation().writeToString(config));
+	}
+
+	@Test
+	public void writeAlignedList() {
+		CommentedConfig config = CommentedConfig.inMemory();
+		List<String> list = Arrays.asList("value1", "value2", "value3");
+
+		config.set("Test.List", list);
+
+		TomlWriter writer = new TomlWriter();
+		writer.setIndentArrayElementsPredicate(objects -> true);
+		String written = writer.writeToString(config);
+
+		System.out.println(written);
+		assertEquals(join("[Test]",
+								"\tList = [",
+								"\t\t\"value1\",",
+								"\t\t\"value2\",",
+								"\t\t\"value3\"",
+								"\t]",
+								""), written);
 	}
 
 	private String join(String... lines) {

--- a/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
+++ b/toml/src/test/java/com/electronwill/nightconfig/toml/TomlWriterTest.java
@@ -276,12 +276,12 @@ public class TomlWriterTest {
 
 		System.out.println(written);
 		assertEquals(join("[Test]",
-								"\tList = [",
-								"\t\t\"value1\",",
-								"\t\t\"value2\",",
-								"\t\t\"value3\"",
-								"\t]",
-								""), written);
+							"\tList = [",
+							"\t\t\"value1\",",
+							"\t\t\"value2\",",
+							"\t\t\"value3\"",
+							"\t]",
+							""), written);
 	}
 
 	private String join(String... lines) {


### PR DESCRIPTION
When the Predicate is set to true, the List ending was written at the beginning of a line ignoring the indentation.

```java
writer.setIndentArrayElementsPredicate(objects -> true);
```

Before:
```toml
[Test]
    List = [
        "value1",
	"value2",
	"value3"
]
```

After:
```toml
[Test]
    List = [
	"value1",
	"value2",
	"value3"
    ]
```

Wouldn't consider this as a bug or anything, also adding a test for it