### PR TITLE
Improve ParsingException by including cursor location when possible

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 // Use the build script defined in buildSrc
 
 dependencies {
+	compileOnly("org.jetbrains:annotations:23.+")
     testImplementation(project(":test-shared"))
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 // Use the build script defined in buildSrc
 
 dependencies {
-	compileOnly("org.jetbrains:annotations:23.+")
+	compileOnly("org.jetbrains:annotations:+")
     testImplementation(project(":test-shared"))
 }
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/AbstractInput.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/AbstractInput.java
@@ -2,6 +2,8 @@ package com.electronwill.nightconfig.core.io;
 
 import com.electronwill.nightconfig.core.utils.IntDeque;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Abstract base class for CharacterInputs.
  *
@@ -12,6 +14,8 @@ public abstract class AbstractInput implements CharacterInput {
 	 * Contains the peeked characters that haven't been read (by the read methods) yet.
 	 */
 	protected final IntDeque deque = new IntDeque();
+	private final AtomicLong line = new AtomicLong();
+	private final AtomicLong column = new AtomicLong();
 
 	/**
 	 * Tries to parse the next character without taking care of the peek deque.
@@ -29,24 +33,57 @@ public abstract class AbstractInput implements CharacterInput {
 	 */
 	protected abstract char directReadChar();
 
+	protected void advance(int r) {
+		if (r == '\n')
+			advanceLine();
+		else advanceColumn();
+	}
+
+	protected void advanceLine() {
+		line.incrementAndGet();
+		column.set(0);
+	}
+
+	protected void advanceColumn() {
+		column.incrementAndGet();
+	}
+
+	@Override
+	public long line() {
+		return line.get();
+	}
+
+	@Override
+	public long column() {
+		return column.get();
+	}
+
 	@Override
 	public int read() {
+		int r;
 		if (!deque.isEmpty()) {
-			return deque.removeFirst();
+			r = deque.removeFirst();
+		} else {
+			r = directRead();
 		}
-		return directRead();
+		advance(r);
+		return r;
 	}
 
 	@Override
 	public char readChar() {
+		char r;
 		if (!deque.isEmpty()) {
 			int next = deque.removeFirst();
 			if (next == -1) {
 				throw ParsingException.notEnoughData();
 			}
-			return (char)next;
+			r = (char)next;
+		} else {
+			r = directReadChar();
 		}
-		return directReadChar();
+		advance(r);
+		return r;
 	}
 
 	@Override

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/AbstractInput.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/AbstractInput.java
@@ -36,6 +36,8 @@ public abstract class AbstractInput implements CharacterInput {
 	protected void advance(int r) {
 		if (r == '\n')
 			advanceLine();
+		else if (r == '\r')
+			column.set(0);
 		else advanceColumn();
 	}
 

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/CharacterInput.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/CharacterInput.java
@@ -11,7 +11,7 @@ package com.electronwill.nightconfig.core.io;
  *
  * @author TheElectronWill
  */
-public interface CharacterInput {
+public interface CharacterInput extends Cursor {
 	/**
 	 * Reads the next character.
 	 *

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/CharsetUnicodeBom.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/CharsetUnicodeBom.java
@@ -92,14 +92,14 @@ class CharsetUnicodeBom extends Charset {
                         // detect UTF-16 BE and LE BOMs: wrong encoding!
                         if (b1 == 0xFE && b2 == 0xFF) {
                             if (utf8Only) {
-                                throw new ParsingException(
+                                throw new ParsingException(null,
                                         "Invalid input: it begins with an UTF-16 BE byte-order mark, but it should be plain UTF-8.");
                             }
                             setupDecoder(StandardCharsets.UTF_16BE);
                             newPosition += 2;
                         } else if (b1 == 0xFF && b2 == 0xFE) {
                             if (utf8Only) {
-                                throw new ParsingException(
+                                throw new ParsingException(null,
                                         "Invalid input: it begins with an UTF-16 LE byte-order mark, but it should be plain UTF-8.");
                             }
                             setupDecoder(StandardCharsets.UTF_16LE);

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/Cursor.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/Cursor.java
@@ -1,0 +1,7 @@
+package com.electronwill.nightconfig.core.io;
+
+public interface Cursor {
+	long line();
+
+	long column();
+}

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/ParsingException.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/ParsingException.java
@@ -1,24 +1,54 @@
 package com.electronwill.nightconfig.core.io;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Thrown when a parsing operation fails.
  *
  * @author TheElectronWill
  */
 public class ParsingException extends RuntimeException {
-	public ParsingException(String message) {
+	private final long line, column;
+
+	public ParsingException(@Nullable Cursor positionReference, String message) {
 		super(message);
+
+		this.line = positionReference == null ? -1 : positionReference.line();
+		this.column = positionReference == null ? -1 : positionReference.column();
 	}
 
-	public ParsingException(String message, Throwable cause) {
+	public ParsingException(@Nullable Cursor positionReference, String message, Throwable cause) {
 		super(message, cause);
+
+		this.line = positionReference == null ? -1 : positionReference.line();
+		this.column = positionReference == null ? -1 : positionReference.column();
+	}
+
+	@Override
+	public String getMessage() {
+		String pos = "";
+		boolean hasLine = line != -1;
+		boolean hasColumn = column != -1;
+		boolean hasAny = hasLine || hasColumn;
+		if (hasAny)
+			pos += " [";
+		if (hasLine)
+			pos += "line " + line;
+		if (hasColumn) {
+			if (hasLine)
+				pos += ", ";
+			pos += "pos " + column;
+		}
+		if (hasAny)
+			pos += "]";
+		return super.getMessage() + pos;
 	}
 
 	public static ParsingException readFailed(Throwable cause) {
-		return new ParsingException("Failed to parse data from Reader", cause);
+		return new ParsingException(null, "Failed to parse data from Reader", cause);
 	}
 
 	public static ParsingException notEnoughData() {
-		return new ParsingException("Not enough data available");
+		return new ParsingException(null, "Not enough data available");
 	}
 }

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/Utils.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/Utils.java
@@ -1,5 +1,7 @@
 package com.electronwill.nightconfig.core.io;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * Serialization utilities.
  *
@@ -48,7 +50,7 @@ public final class Utils {
 	 * @param base  the base of the number
 	 * @return the long value represented by the CharsWrapper
 	 */
-	public static long parseLong(CharsWrapper chars, int base) {
+	public static long parseLong(CharsWrapper chars, int base, @Nullable Cursor cursor) {
 		// Optimized lightweight parsing
 		int offset = chars.offset;
 		boolean negative = false;
@@ -64,7 +66,7 @@ public final class Utils {
 		for (int i = chars.limit - 1; i >= offset; i--) {
 			int digitValue = Character.digit(array[i], base);
 			if (digitValue == -1) {//invalid digit in the specified base
-				throw new ParsingException("Invalid value: " + chars);
+				throw new ParsingException(cursor, "Invalid value: " + chars);
 			}
 			value += digitValue * coefficient;
 			coefficient *= base;
@@ -75,12 +77,13 @@ public final class Utils {
 	/**
 	 * Parses a CharsWrapper that represents an int value in the specified base.
 	 *
-	 * @param chars the CharsWrapper representing an int
-	 * @param base  the base of the number
+	 * @param chars  the CharsWrapper representing an int
+	 * @param base   the base of the number
+	 * @param cursor
 	 * @return the int value represented by the CharsWrapper
 	 */
-	public static int parseInt(CharsWrapper chars, int base) {
-		return (int)parseLong(chars, base);
+	public static int parseInt(CharsWrapper chars, int base, @Nullable Cursor cursor) {
+		return (int)parseLong(chars, base, cursor);
 	}
 
 	/**

--- a/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
+++ b/core/src/test/java/com/electronwill/nightconfig/core/io/UtilsTest.java
@@ -8,9 +8,9 @@ class UtilsTest {
 
 	@Test
 	void parseLong() {
-		assertEquals(123456789L, Utils.parseLong(new CharsWrapper("123456789"), 10));
-		assertEquals(0, Utils.parseLong(new CharsWrapper("0"), 10));
-		assertEquals(-123456789L, Utils.parseLong(new CharsWrapper("-123456789"), 10));
-		assertEquals(0xff, Utils.parseLong(new CharsWrapper("ff"), 16));
+		assertEquals(123456789L, Utils.parseLong(new CharsWrapper("123456789"), 10, null));
+		assertEquals(0, Utils.parseLong(new CharsWrapper("0"), 10, null));
+		assertEquals(-123456789L, Utils.parseLong(new CharsWrapper("-123456789"), 10, null));
+		assertEquals(0xff, Utils.parseLong(new CharsWrapper("ff"), 16, null));
 	}
 }

--- a/hocon/src/main/java/com/electronwill/nightconfig/hocon/HoconParser.java
+++ b/hocon/src/main/java/com/electronwill/nightconfig/hocon/HoconParser.java
@@ -57,7 +57,7 @@ public final class HoconParser implements ConfigParser<CommentedConfig> {
 				put(parsed, destination, parsingMode);
 			}
 		} catch (Exception e) {
-			throw new ParsingException("HOCON parsing failed", e);
+			throw new ParsingException(null, "HOCON parsing failed", e);
 		}
 	}
 

--- a/toml/build.gradle.kts
+++ b/toml/build.gradle.kts
@@ -9,5 +9,6 @@ multiRelease {
 
 dependencies {
 	implementation(project(":core"))
-    testImplementation(project(":test-shared"))
+	compileOnly("org.jetbrains:annotations:+")
+	testImplementation(project(":test-shared"))
 }

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/ArrayParser.java
@@ -24,7 +24,7 @@ final class ArrayParser {
 				if (nextChar == ']') {
 					return list;
 				}
-				throw new ParsingException("Unexpected character in array: '"
+				throw new ParsingException(input, "Unexpected character in array: '"
 										   + nextChar
 										   + "' - "
 										   + "Expected end of array because of the leading comma.");
@@ -36,7 +36,7 @@ final class ArrayParser {
 				return list;
 			}
 			if (after != ',') {// Invalid character between two elements of the array
-				throw new ParsingException("Invalid separator '" + after + "' in array.");
+				throw new ParsingException(input, "Invalid separator '" + after + "' in array.");
 			}
 		}
 	}

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/StringParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/StringParser.java
@@ -61,7 +61,7 @@ final class StringParser {
 					input.pushBack(nextNonSpace);
 					continue;
 				} else if (next == '\t' || next == ' ') {
-					throw new ParsingException("Invalid escapement: \\" + next);
+					throw new ParsingException(input, "Invalid escapement: \\" + next);
 				}
 				builder.write(escape(next, input));
 			} else {
@@ -122,12 +122,12 @@ final class StringParser {
 				return '\t';
 			case 'u':
 				CharsWrapper chars = input.readChars(4);
-				return (char)Utils.parseInt(chars, 16);
+				return (char)Utils.parseInt(chars, 16, input);
 			case 'U':
 				chars = input.readChars(8);
-				return (char)Utils.parseInt(chars, 16);
+				return (char)Utils.parseInt(chars, 16, input);
 			default:
-				throw new ParsingException("Invalid escapement: \\" + c);
+				throw new ParsingException(input, "Invalid escapement: \\" + c);
 		}
 	}
 

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TemporalParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TemporalParser.java
@@ -1,6 +1,7 @@
 package com.electronwill.nightconfig.toml;
 
 import com.electronwill.nightconfig.core.io.CharsWrapper;
+import com.electronwill.nightconfig.core.io.Cursor;
 import com.electronwill.nightconfig.core.io.ParsingException;
 import com.electronwill.nightconfig.core.io.Utils;
 import java.time.LocalDate;
@@ -18,7 +19,6 @@ import java.time.temporal.Temporal;
  * @see <a href="https://github.com/toml-lang/toml#user-content-local-time">TOML specification - LocalTime</a>
  */
 final class TemporalParser {
-
 	private static final char[] ALLOWED_DT_SEPARATORS = {'T', 't', ' '};
 	private static final char[] OFFSET_INDICATORS = {'Z', '+', '-'};
 
@@ -39,7 +39,7 @@ final class TemporalParser {
 		}
 		char dateTimeSeparator = chars.get(10);
 		if (!Utils.arrayContains(ALLOWED_DT_SEPARATORS, dateTimeSeparator)) {
-			throw new ParsingException(
+			throw new ParsingException(null,
 					"Invalid separator between date and time: '" + dateTimeSeparator + "'.");
 		}
 		CharsWrapper afterDate = chars.subView(11);
@@ -57,9 +57,9 @@ final class TemporalParser {
 		CharsWrapper yearChars = chars.subView(0, 4);
 		CharsWrapper monthChars = chars.subView(5, 7);
 		CharsWrapper dayChars = chars.subView(8, 10);
-		int year = Utils.parseInt(yearChars, 10);
-		int month = Utils.parseInt(monthChars, 10);
-		int day = Utils.parseInt(dayChars, 10);
+		int year = Utils.parseInt(yearChars, 10, null);
+		int month = Utils.parseInt(monthChars, 10, null);
+		int day = Utils.parseInt(dayChars, 10, null);
 		return LocalDate.of(year, month, day);
 	}
 
@@ -67,9 +67,9 @@ final class TemporalParser {
 		CharsWrapper hourChars = chars.subView(0, 2);
 		CharsWrapper minuteChars = chars.subView(3, 5);
 		CharsWrapper secondChars = chars.subView(6, 8);
-		int hour = Utils.parseInt(hourChars, 10);
-		int minutes = Utils.parseInt(minuteChars, 10);
-		int seconds = Utils.parseInt(secondChars, 10);
+		int hour = Utils.parseInt(hourChars, 10, null);
+		int minutes = Utils.parseInt(minuteChars, 10, null);
+		int seconds = Utils.parseInt(secondChars, 10, null);
 		int nanos;
 
 		if (chars.length() > 8) {
@@ -77,7 +77,7 @@ final class TemporalParser {
 			if (fractionChars.length() > 9) {
 				fractionChars = fractionChars.subView(0, 9);// truncates if too many digits
 			}
-			int value = Utils.parseInt(fractionChars, 10);
+			int value = Utils.parseInt(fractionChars, 10, null);
 			int coeff = (int)Math.pow(10, 9 - fractionChars.length());
 			nanos = value * coeff;
 		} else {

--- a/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
+++ b/toml/src/main/java/com/electronwill/nightconfig/toml/TomlParser.java
@@ -97,7 +97,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 			}
 			if (isArray) {// It's an element of an array of tables
 				if (parentMap == null) {
-					throw new ParsingException("Cannot create entry "
+					throw new ParsingException(input, "Cannot create entry "
 											   + path
 											   + " because of an invalid "
 											   + "parent that isn't a table.");
@@ -111,7 +111,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 				arrayOfTables.add(table);
 			} else {// It's a table
 				if (parentMap == null) {
-					throw new ParsingException("Cannot create entry "
+					throw new ParsingException(input, "Cannot create entry "
 											   + path
 											   + " because of an invalid "
 											   + "parent that isn't a table.");
@@ -127,7 +127,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 						CommentedConfig commentedTable = CommentedConfig.fake(table);
 						TableParser.parseNormal(input, this, commentedTable);
 					} else if (configWasEmpty) {
-						throw new ParsingException("Entry " + path + " has been defined twice.");
+						throw new ParsingException(input, "Entry " + path + " has been defined twice.");
 					}
 				}
 			}
@@ -162,7 +162,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 			}
 			if (this.isInlineTable(currentConfig)) {
 				// reject modification of inline tables
-				throw new ParsingException("Cannot modify an inline table after its creation. Key path: " + path);
+				throw new ParsingException(null, "Cannot modify an inline table after its creation. Key path: " + path);
 			}
 		}
 		return currentConfig;
@@ -171,7 +171,7 @@ public final class TomlParser implements ConfigParser<CommentedConfig> {
 	private void checkContainsOnlySubtables(Config table, List<String> path) {
 		for (Object value : table.valueMap().values()) {
 			if (!(value instanceof Config)) {
-				throw new ParsingException("Table with path " + path + " has been declared twice.");
+				throw new ParsingException(null, "Table with path " + path + " has been declared twice.");
 			}
 		}
 	}

--- a/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlParser.java
+++ b/yaml/src/main/java/com/electronwill/nightconfig/yaml/YamlParser.java
@@ -78,7 +78,7 @@ public final class YamlParser implements ConfigParser<Config> {
 				parsingMode.put(destination, Collections.singletonList(entry.getKey()), convertValue(entry.getValue(), destination));
 			}
 		} catch (Exception e) {
-			throw new ParsingException("YAML parsing failed", e);
+			throw new ParsingException(null, "YAML parsing failed", e);
 		}
 	}
 


### PR DESCRIPTION
Closes #105, Closes #165

This PR introduces the `Cursor` interface that has methods to gather information about cursor information.
If a `Cursor` is passed to a `ParsingException`, the exception message is being appended with line and position information obtained from the `Cursor` at the moment when the exception is thrown.

Some internal things; such as private helper methods and some (supposedly internal) utility methods from `com.electronwill.nightconfig.core.io.Utils` had a new, `@Nullable` parameter added in order to pass a `Cursor`.

Documentation for added code is still missing.
Hocon tests are failing for a reason outside of this PR.
Needs in-depth testing and new unit tests.