### PR TITLE
Allow custom `Config` storage in `ConfigSpec`

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/ConfigSpec.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/ConfigSpec.java
@@ -66,7 +66,7 @@ public class ConfigSpec {
 		this(Config.inMemoryUniversal());
 	}
 
-	ConfigSpec(Config storage) {
+	public ConfigSpec(Config storage) {
 		this.storage = storage;
 	}
 


### PR DESCRIPTION
I noticed Forge's `ConfigSpec.Builder` could be simplified if it were able to extend NightConfig's `ConfigSpec`. However, the constructor to allow setting a custom storage with comments is currently package-private. This tiny PR widens the access so that `ConfigSpec` can be extended to support comments, among other things.