### PR TITLE
Set FileWatcher executor threads to be daemon threads

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
@@ -457,7 +457,12 @@ public final class FileWatcher {
 		@Override
 		public void run() {
 			// executor (in yet another thread) to schedule debounced actions
-			ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+			ThreadFactory delegatedFactory = Executors.defaultThreadFactory();
+			ScheduledExecutorService executor = Executors.newScheduledThreadPool(1, runnable -> {
+				Thread thread = delegatedFactory.newThread(runnable);
+				thread.setDaemon(true);
+				return thread;
+			});
 
 			// future that initiated the shutdown and needs to be completed with the result or error
 			CompletableFuture<Void> shutdownFuture = null;

--- a/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/file/FileWatcher.java
@@ -457,12 +457,8 @@ public final class FileWatcher {
 		@Override
 		public void run() {
 			// executor (in yet another thread) to schedule debounced actions
-			ThreadFactory delegatedFactory = Executors.defaultThreadFactory();
-			ScheduledExecutorService executor = Executors.newScheduledThreadPool(1, runnable -> {
-				Thread thread = delegatedFactory.newThread(runnable);
-				thread.setDaemon(true);
-				return thread;
-			});
+			ThreadFactory threadFactory = new NamedDaemonThreadFactory("FileWatcher-", "-thread-");
+			ScheduledExecutorService executor = Executors.newScheduledThreadPool(1, threadFactory);
 
 			// future that initiated the shutdown and needs to be completed with the result or error
 			CompletableFuture<Void> shutdownFuture = null;
@@ -676,4 +672,21 @@ public final class FileWatcher {
 		PUT, ADD, REMOVE, POISON
 	}
 
+	private static class NamedDaemonThreadFactory implements ThreadFactory {
+		private static final AtomicInteger FACTORY_NUMBER = new AtomicInteger(1);
+		private final AtomicInteger threadNumber = new AtomicInteger(1);
+		private final String namePrefix;
+
+		NamedDaemonThreadFactory(String prefix, String suffix) {
+			this.namePrefix = prefix + FACTORY_NUMBER.getAndIncrement() + suffix;
+		}
+
+		@Override
+		public Thread newThread(Runnable r) {
+			Thread t = new Thread(r, namePrefix + threadNumber.getAndIncrement());
+			t.setDaemon(true);
+			t.setPriority(Thread.NORM_PRIORITY);
+			return t;
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes #187 by configuring the `ScheduledExecutorService` to create daemon threads, instead of non-daemon threads.

Instead of creating our own bespoke thread factory implementation, we instead defer to a default thread factory instance but explicitly set the thread to be a daemon. We could also create our own thread factory, with its own separate numbering and a custom prefix explicitly marking the thread as belonging to a `FileWatcher` instance.