### PR TITLE
Update parse exception message "invalid value" -> "invalid integer"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ To **run all the tests**, do:
 gradle test-everything
 ```
 
+You may need to update the submodules first:
+```sh
+git submodule update --init
+```
+
 The results will be in the build directory of each module, in a subdirectory per test task:
 - Results of `core:test` in [`./core/build/reports/tests/test/index.html`](./core/build/reports/tests/test/index.html).
 - Results of `core:java11Test` in [`./core/build/reports/tests/java11Test/index.html`](./core/build/reports/tests/java11Test/index.html).

--- a/core/src/main/java/com/electronwill/nightconfig/core/io/Utils.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/Utils.java
@@ -64,7 +64,7 @@ public final class Utils {
 		for (int i = chars.limit - 1; i >= offset; i--) {
 			int digitValue = Character.digit(array[i], base);
 			if (digitValue == -1) {//invalid digit in the specified base
-				throw new ParsingException("Invalid value: " + chars);
+				throw new ParsingException("Invalid integer: " + chars);
 			}
 			value += digitValue * coefficient;
 			coefficient *= base;


### PR DESCRIPTION
Currently, if the user misswrote `foo = bar` (missing quotes), the `invalid value: bar` message don't point out that an integer was expected (without looking at the stack trace.)

Also point the contributors to update the submodules first (as the test suite will fail otherwise, i.e. `/test-multiple/src/test/resources/toml-test/` isn't pulled.)