### PR TITLE
Fix #195: NoSuchFileException when writing config to relative path with ATOMIC_REPLACE

### DIFF
--- a/core/src/main/java/com/electronwill/nightconfig/core/io/IoUtils.java
+++ b/core/src/main/java/com/electronwill/nightconfig/core/io/IoUtils.java
@@ -73,7 +73,7 @@ public final class IoUtils {
 	 * @return a filename for the temporary file (the file is not created by this method)
 	 */
 	public static String tempConfigFileName(Path originalFile) {
-		String filename = originalFile.toString();
+		String filename = originalFile.getFileName().toString();
 		String[] parts = splitOnce(filename, '.');
 		if (parts.length == 1) {
 			return filename + ".new.tmp";

--- a/core/src/test/java11/com/electronwill/nightconfig/core/file/AtomicWriteTest.java
+++ b/core/src/test/java11/com/electronwill/nightconfig/core/file/AtomicWriteTest.java
@@ -1,0 +1,41 @@
+package com.electronwill.nightconfig.core.file;
+
+import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.io.WritingMode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AtomicWriteTest {
+
+	@TempDir
+	static Path tmp;
+
+	/**
+	 * Regression test for <a href="https://github.com/TheElectronWill/night-config/issues/195">issue 195</a>,
+	 * that occurred when saving to a relative path with multiple components.
+	 */
+	@Test
+	public void testAtomicWrite() throws IOException {
+		// Do a bit of work to create a relative path with multiple components
+		Path tmpRelative = Paths.get(".").toAbsolutePath().relativize(tmp);
+		Path configPath = tmpRelative.resolve("a/b/config.txt");
+		Files.createDirectories(configPath.getParent());
+
+		// Trivial config
+		var format = new Util.TestFormat(true);
+		var config = Config.inMemory();
+		config.set("test", true);
+
+		// Try to save it
+		format.createWriter().write(config, configPath, WritingMode.REPLACE_ATOMIC);
+
+		assertTrue(Files.exists(configPath));
+	}
+}


### PR DESCRIPTION
The fix is pretty simple: add `.getFileName()` in `tempConfigFileName` to only consider the last path element. I also added a test that failed before this change and now succeeds.