### PR TITLE
Partially fix record deserialization

### DIFF
--- a/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
+++ b/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
@@ -63,7 +63,7 @@ final class ConfigToPojoDeserializer
 		    DeserializerContext ctx) {
 		var components = objectClass.getRecordComponents();
 		var constructor = getCanonicalRecordConstructor(objectClass, components);
-		var componentKeys = new String[components.length];
+		var componentFields = new Field[components.length];
 		var componentValues = new Object[components.length];
 		for (int i = 0; i < components.length; i++) {
 			Field field;
@@ -71,15 +71,17 @@ final class ConfigToPojoDeserializer
 				field = objectClass.getDeclaredField(components[i].getName());
 			} catch (NoSuchFieldException e) {
 				throw new SerdeException(
-						"Failed to get declared field " + components[i].getName()
-							+ " of record " + objectClass, e);
+					"Failed to get declared field " + components[i].getName()
+						+ " of record " + objectClass, e);
 			}
-			componentKeys[i] = configKey(field);
-			Object configValue = value.getRaw(Collections.singletonList(componentKeys[i]));
+			componentFields[i] = field;
+		}
+		for (int i = 0; i < components.length; i++) {
+			Object configValue = value.getRaw(Collections.singletonList(configKey(componentFields[i])));
 			if (configValue == null) {
 				// missing component!
 				// find all the missing components to emit a more helpful error message
-				List<String> missingComponents = Arrays.stream(componentKeys)
+				List<String> missingComponents = Arrays.stream(componentFields).map(f -> configKey(f))
 						.filter(c -> !value.contains(c)).collect(Collectors.toList());
 				var missingComponentsStr = String.join(", ", missingComponents);
 				throw new SerdeException(
@@ -93,7 +95,7 @@ final class ConfigToPojoDeserializer
 			}
 
 			// deserialize
-			TypeConstraint resultType = new TypeConstraint(field.getGenericType());
+			TypeConstraint resultType = new TypeConstraint(componentFields[i].getGenericType());
 			componentValues[i] = ctx.deserializeValue(configValue, Optional.of(resultType));
 		}
 		try {

--- a/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
+++ b/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
@@ -1,5 +1,6 @@
 package com.electronwill.nightconfig.core.serde;
 
+import java.lang.reflect.Field;
 import java.util.Optional;
 import java.util.Collections;
 import java.util.Arrays;
@@ -11,6 +12,8 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.RecordComponent;
 
 import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.electronwill.nightconfig.core.serde.annotations.SerdeKey;
+
 import static com.electronwill.nightconfig.core.NullObject.NULL_OBJECT;
 
 /**
@@ -59,14 +62,23 @@ final class ConfigToPojoDeserializer
 	private Object deserializeToRecord(UnmodifiableConfig value, Class<?> objectClass) {
 		var components = objectClass.getRecordComponents();
 		var constructor = getCanonicalRecordConstructor(objectClass, components);
+		var componentKeys = new String[components.length];
 		var componentValues = new Object[components.length];
 		for (int i = 0; i < components.length; i++) {
-			RecordComponent comp = components[i];
-			Object configValue = value.getRaw(Collections.singletonList(comp.getName()));
+			Field field;
+			try {
+				field = objectClass.getDeclaredField(components[i].getName());
+			} catch (NoSuchFieldException e) {
+				throw new SerdeException(
+						"Failed to get declared field " + components[i].getName()
+							+ " of record " + objectClass, e);
+			}
+			componentKeys[i] = configKey(field);
+			Object configValue = value.getRaw(Collections.singletonList(componentKeys[i]));
 			if (configValue == null) {
 				// missing component!
 				// find all the missing components to emit a more helpful error message
-				List<String> missingComponents = Arrays.stream(components).map(c -> c.getName())
+				List<String> missingComponents = Arrays.stream(componentKeys)
 						.filter(c -> !value.contains(c)).collect(Collectors.toList());
 				var missingComponentsStr = String.join(", ", missingComponents);
 				throw new SerdeException(
@@ -99,5 +111,10 @@ final class ConfigToPojoDeserializer
 			throw new SerdeException(
 					"Failed to get the canonical constructor of record " + cls, e);
 		}
+	}
+
+	private static String configKey(Field field) {
+		SerdeKey keyAnnot = field.getAnnotation(SerdeKey.class);
+		return keyAnnot == null ? field.getName() : keyAnnot.value();
 	}
 }

--- a/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
+++ b/core/src/main/java17/com/electronwill/nightconfig/core/serde/ConfigToPojoDeserializer.java
@@ -35,7 +35,7 @@ final class ConfigToPojoDeserializer
 					"Could not find a concrete type that can satisfy the constraint " + t));
 
 			if (cls.isRecord()) {
-				return deserializeToRecord(value, cls);
+				return deserializeToRecord(value, cls, ctx);
 			} else {
 				return deserializeToNormalClass(value, cls, ctx);
 			}
@@ -59,7 +59,8 @@ final class ConfigToPojoDeserializer
 		return instance;
 	}
 
-	private Object deserializeToRecord(UnmodifiableConfig value, Class<?> objectClass) {
+	private Object deserializeToRecord(UnmodifiableConfig value, Class<?> objectClass,
+		    DeserializerContext ctx) {
 		var components = objectClass.getRecordComponents();
 		var constructor = getCanonicalRecordConstructor(objectClass, components);
 		var componentKeys = new String[components.length];
@@ -90,7 +91,10 @@ final class ConfigToPojoDeserializer
 				// component of value null
 				configValue = null;
 			}
-			componentValues[i] = configValue;
+
+			// deserialize
+			TypeConstraint resultType = new TypeConstraint(field.getGenericType());
+			componentValues[i] = ctx.deserializeValue(configValue, Optional.of(resultType));
 		}
 		try {
 			return constructor.newInstance(componentValues);

--- a/core/src/test/java17/com/electronwill/nightconfig/core/serde/SerdeWithRecordTest.java
+++ b/core/src/test/java17/com/electronwill/nightconfig/core/serde/SerdeWithRecordTest.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.electronwill.nightconfig.core.serde.annotations.SerdeComment;
+import com.electronwill.nightconfig.core.serde.annotations.SerdeKey;
 import org.junit.jupiter.api.Test;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
@@ -21,6 +23,16 @@ public class SerdeWithRecordTest {
 
     static record Name(String username, String nickname) {
     }
+
+	static record SimpleAnnotations(
+		@SerdeComment("This is uniqueId")
+		@SerdeKey("uniqueId")
+		String myUniqueId,
+		@SerdeComment("This is myUid")
+		@SerdeKey("myUid")
+		int uid
+	) {
+	}
 
     static class Player {
         int id = 123;
@@ -94,6 +106,19 @@ public class SerdeWithRecordTest {
         var serialized = ObjectSerializer.builder().build().serialize(new Point3d(123, 456, 789), Config::inMemory);
         assertEquals(conf, serialized);
     }
+
+	@Test
+	public void testAnnotatedRecordsDirect() {
+		var conf = Config.inMemory();
+		conf.set("uniqueId", "abc");
+		conf.set("myUid", 123);
+
+		var deserialized = ObjectDeserializer.builder().build().deserializeToRecord(conf, SimpleAnnotations.class);
+		assertEquals(new SimpleAnnotations("abc", 123), deserialized);
+
+		var serialized = ObjectSerializer.builder().build().serialize(new SimpleAnnotations("abc", 123), Config::inMemory);
+		assertEquals(conf, serialized);
+	}
 
     @Test
     public void testFieldsRecords() {

--- a/core/src/test/java17/com/electronwill/nightconfig/core/serde/SerdeWithRecordTest.java
+++ b/core/src/test/java17/com/electronwill/nightconfig/core/serde/SerdeWithRecordTest.java
@@ -3,6 +3,7 @@ package com.electronwill.nightconfig.core.serde;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -23,6 +24,9 @@ public class SerdeWithRecordTest {
 
     static record Name(String username, String nickname) {
     }
+
+	static record SimpleMaps(Map<String, String> simpleMap) {
+	}
 
 	static record SimpleAnnotations(
 		@SerdeComment("This is uniqueId")
@@ -106,6 +110,24 @@ public class SerdeWithRecordTest {
         var serialized = ObjectSerializer.builder().build().serialize(new Point3d(123, 456, 789), Config::inMemory);
         assertEquals(conf, serialized);
     }
+
+	@Test
+	public void testRecordsWithMapsDirect() {
+		var conf = Config.inMemory();
+		conf.set("simpleMap.key1", "value1");
+		conf.set("simpleMap.key2", "value2");
+		conf.set("simpleMap.key3", null);
+		var object = new SimpleMaps(new HashMap<>());
+		object.simpleMap.put("key1", "value1");
+		object.simpleMap.put("key2", "value2");
+		object.simpleMap.put("key3", null);
+
+		var deserialized = ObjectDeserializer.builder().build().deserializeToRecord(conf, SimpleMaps.class);
+		assertEquals(object, deserialized);
+
+		var serialized = ObjectSerializer.builder().build().serialize(object, Config::inMemory);
+		assertEquals(conf, serialized);
+	}
 
 	@Test
 	public void testAnnotatedRecordsDirect() {


### PR DESCRIPTION
This PR adds support for the `SerdeKey` annotation when deserializing records.
Additionally, the values returned by the Config object are now also deserialized by `DeserializerContext.deserializeValue()`.

At first I wanted to split `DeserializerContext.deserializeFields()` into smaller methods, so I could add a function specifically for records without copying all the private methods, but couldn't think of a clean way.
Since I'm not too familiar with this project yet, I didn't want to make larger changes that might also impact the API.

So the remaining annotations that aren't checked yet when deserializing records are:
- `SerdeDefault`: can be supported, but the current methods check the field value of a class instance. That wouldn't be necessary here.
- `SerdeAssert`: can be supported, as long as no instance methods are be checked.
- `SerdeSkipDeserializingIf`: can't be supported, as all record components need to have a value.

---

Fixes #203